### PR TITLE
Add styled HTML email for GameFlash

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skrypt do podsumowywania newsow z branzy gier.
 
 ## Jak to dziala
 
-Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a wynik trafia do zbiorczego e-maila.
+Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`.
 
 ## Wymagania
 
@@ -49,7 +49,7 @@ Projekt uzywa `unittest`. Standardowa komenda:
 uv run python -m unittest discover -s tests -p "test_*.py"
 ```
 
-Testy obejmuja Google Sheets, parser listingu oraz finalny pipeline przetwarzania linkow w trybie stubowanym.
+Testy obejmuja Google Sheets, parser listingu, finalny pipeline przetwarzania linkow w trybie stubowanym oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
 
 ## Przykladowy wynik
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,3 +97,24 @@ Zakres:
 - integracja nowej deduplikacji z istniejącym etapem podsumowania i e-maila
 - aktualizacja README i pozostałej dokumentacji operacyjnej po implementacji
 - przygotowanie testów i smoke testów dla nowego przepływu bez realnego IO
+
+---
+
+## Milestone 1.3: Stylowany e-mail HTML dla GameFlash (done)
+
+Cel:
+- zastapic obecna wiadomosc `plain text` stylowanym mailem HTML dopasowanym do newsow gamingowych
+- zachowac kompatybilny fallback `plain text` i brak regresji w istniejacym pipeline'ie wysylki
+
+Definition of Done:
+- aplikacja generuje wiadomosc multipart zawierajaca `text/plain` oraz `text/html`
+- wariant HTML prezentuje kazdy news jako osobna, czytelna sekcje z tytulem, streszczeniem i CTA do pelnego artykulu
+- styl HTML wykorzystuje osadzony CSS bez zaleznosci od zewnetrznych fontow, CDN, zdalnych stylow i hostowanych obrazow jako wymogu v1
+- uklad wiadomosci pozostaje czytelny dla wielu newsow oraz na waskich ekranach
+- testy lokalne pokrywaja render HTML, fallback `plain text` i brak zaleznosci od realnego SMTP
+
+Zakres:
+- rozszerzenie warstwy mailowej o renderer HTML dla wiadomosci GameFlash
+- przygotowanie maila multipart z warstwa `text/plain` i `text/html`
+- zaprojektowanie nowoczesnej, gamingowej stylistyki wiadomosci
+- dostosowanie testow jednostkowych i smoke testow do nowego formatu e-maila

--- a/STATUS.md
+++ b/STATUS.md
@@ -7,7 +7,8 @@
 - Stan przetworzonych linkow jest odczytywany i zapisywany w Google Sheets.
 - Listing newsow jest parsowany bezposrednio z HTML bez uzycia LLM.
 - Pelna tresc artykulow jest pobierana przez mirror Jina.
-- Testy `unittest` dla Milestone 1.0-1.2 przechodza lokalnie.
+- Wiadomosc e-mail jest wysylana jako multipart z fallbackiem `plain text` i stylowana warstwa HTML.
+- Testy `unittest` dla Milestone 1.0-1.3 przechodza lokalnie.
 
 ## Co jest skończone
 - Dodanie dokumentow operacyjnych repo.
@@ -15,6 +16,7 @@
 - Milestone 1.0: integracja z Google Sheets jako baza linkow.
 - Milestone 1.1: deterministyczna ekstrakcja linkow z HTML.
 - Milestone 1.2: finalny pipeline przetwarzania linkow i obsluga bledow po append.
+- Milestone 1.3: stylowany e-mail HTML dla GameFlash z fallbackiem `plain text`.
 - Bazowy zestaw testow `unittest` dla Google Sheets i deduplikacji.
 - Aktualizacja bezposrednich zaleznosci do najnowszych kompatybilnych wersji.
 
@@ -35,3 +37,4 @@
 - 2026-03-22: wdrozenie Milestone 1.1, testy lokalne i walidacja live parsera listingu.
 - 2026-03-22: wdrozenie Milestone 1.2, testy lokalne i walidacja live finalnego pipeline'u.
 - 2026-03-22: model LLM przeniesiony do `LLM_MODEL` w `.env` i odswiezone zaleznosci wykonawcze.
+- 2026-03-22: wdrozenie Milestone 1.3, stylowany e-mail HTML, fallback `plain text` i testy lokalne warstwy maili.

--- a/emails/gmail.py
+++ b/emails/gmail.py
@@ -2,8 +2,150 @@
 
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+import html
+import re
 import smtplib
 import ssl
+
+SEPARATOR = "################################"
+TITLE_RE = re.compile(r"^Tytu[łl]:\s*(.+)$", re.MULTILINE)
+SUMMARY_RE = re.compile(r"Podsumowanie:\s*(.+?)(?:\n\s*\nLink:|\nLink:|\Z)", re.DOTALL)
+LINK_RE = re.compile(r"^Link:\s*(\S+)\s*$", re.MULTILINE)
+
+
+def _normalize_news_entry(news_entry: str) -> str:
+    """Usuwa techniczne separatory i porzadkuje biale znaki."""
+    cleaned = str(news_entry).replace(SEPARATOR, "").strip()
+    return cleaned
+
+
+def _parse_news_entry(news_entry: str) -> dict:
+    """Wyciaga tytul, podsumowanie i link z pojedynczego wpisu."""
+    cleaned = _normalize_news_entry(news_entry)
+
+    title_match = TITLE_RE.search(cleaned)
+    summary_match = SUMMARY_RE.search(cleaned)
+    link_match = LINK_RE.search(cleaned)
+
+    return {
+        "title": title_match.group(1).strip() if title_match else "Nowy news gamingowy",
+        "summary": summary_match.group(1).strip() if summary_match else cleaned,
+        "link": link_match.group(1).strip() if link_match else "",
+    }
+
+
+def build_plain_text_body(news_to_send: list) -> str:
+    """Buduje fallback tekstowy dla klientow bez wsparcia HTML."""
+    normalized_entries = []
+    for news_entry in news_to_send:
+        cleaned = _normalize_news_entry(news_entry)
+        if cleaned:
+            normalized_entries.append(cleaned)
+
+    return "\n\n" + ("\n\n---\n\n".join(normalized_entries) if normalized_entries else "")
+
+
+def _format_html_text(value: str) -> str:
+    """Escapuje tekst i zachowuje podzial na akapity."""
+    return "<br>".join(html.escape(value).splitlines())
+
+
+def build_email_html(news_to_send: list) -> str:
+    """Buduje stylowany e-mail HTML dla newsow gamingowych."""
+    news_items = [_parse_news_entry(news_entry) for news_entry in news_to_send]
+
+    cards = []
+    for item in news_items:
+        title_html = html.escape(item["title"])
+        summary_html = _format_html_text(item["summary"])
+        cta_html = ""
+        if item["link"]:
+            escaped_link = html.escape(item["link"], quote=True)
+            cta_html = (
+                f'<a class="button" href="{escaped_link}" target="_blank" '
+                f'rel="noopener noreferrer">Czytaj pełny artykuł</a>'
+            )
+
+        cards.append(
+            f"""
+            <tr>
+              <td class="card">
+                <p class="eyebrow">GameFlash News</p>
+                <h2>{title_html}</h2>
+                <p class="summary">{summary_html}</p>
+                {cta_html}
+              </td>
+            </tr>
+            """
+        )
+
+    if not cards:
+        cards.append(
+            """
+            <tr>
+              <td class="card">
+                <p class="eyebrow">GameFlash News</p>
+                <h2>Brak nowych newsow</h2>
+                <p class="summary">W tym przebiegu nie przygotowano zadnych nowych podsumowan do wysylki.</p>
+              </td>
+            </tr>
+            """
+        )
+
+    cards_html = "\n".join(cards)
+
+    return f"""<!DOCTYPE html>
+<html lang="pl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>GameFlash - podsumowanie newsow</title>
+<style type="text/css">
+  body {{ margin: 0; padding: 0; background: #08111f; font-family: Arial, Helvetica, sans-serif; color: #d9e7ff; }}
+  a {{ color: #6cf2ff; }}
+  .wrapper {{ width: 100%; table-layout: fixed; padding: 24px 12px; background:
+    radial-gradient(circle at top, #13233f 0%, #08111f 55%, #050a13 100%); }}
+  .main {{ width: 100%; max-width: 680px; margin: 0 auto; border-collapse: collapse; }}
+  .hero {{ padding: 32px 28px 24px; background: linear-gradient(135deg, #111c31 0%, #0f2c44 45%, #0a3f54 100%); border: 1px solid #1d3556; border-radius: 20px 20px 0 0; }}
+  .hero h1 {{ margin: 0 0 10px; font-size: 30px; line-height: 1.1; color: #ffffff; }}
+  .hero p {{ margin: 0; font-size: 15px; line-height: 1.6; color: #b7cbed; }}
+  .accent {{ color: #7bf7c7; }}
+  .card {{ padding: 24px 28px; background: #0d1728; border-left: 1px solid #1d3556; border-right: 1px solid #1d3556; border-bottom: 1px solid #1d3556; }}
+  .eyebrow {{ margin: 0 0 10px; font-size: 11px; font-weight: bold; letter-spacing: 0.12em; text-transform: uppercase; color: #6cf2ff; }}
+  .card h2 {{ margin: 0 0 12px; font-size: 22px; line-height: 1.3; color: #ffffff; }}
+  .summary {{ margin: 0 0 18px; font-size: 15px; line-height: 1.7; color: #d9e7ff; }}
+  .button {{ display: inline-block; padding: 12px 20px; border-radius: 999px; background: linear-gradient(135deg, #00d4ff 0%, #2af598 100%); color: #04111f !important; font-size: 13px; font-weight: bold; text-decoration: none; }}
+  .footer {{ padding: 18px 28px 28px; background: #0d1728; border-left: 1px solid #1d3556; border-right: 1px solid #1d3556; border-bottom: 1px solid #1d3556; border-radius: 0 0 20px 20px; font-size: 12px; line-height: 1.6; color: #8ca4c7; text-align: center; }}
+  @media only screen and (max-width: 620px) {{
+    .wrapper {{ padding: 16px 8px; }}
+    .hero {{ padding: 24px 20px 20px; }}
+    .hero h1 {{ font-size: 24px !important; }}
+    .card {{ padding: 20px; }}
+    .card h2 {{ font-size: 20px !important; }}
+    .summary {{ font-size: 14px !important; }}
+    .button {{ display: block; text-align: center; }}
+  }}
+</style>
+</head>
+<body>
+  <center class="wrapper">
+    <table class="main" role="presentation" cellpadding="0" cellspacing="0">
+      <tr>
+        <td class="hero">
+          <p class="eyebrow">Gaming Brief</p>
+          <h1>GameFlash <span class="accent">Level Up</span></h1>
+          <p>Najnowsze newsy ze swiata gier w bardziej czytelnej, nowoczesnej formie.</p>
+        </td>
+      </tr>
+      {cards_html}
+      <tr>
+        <td class="footer">Wiadomosc wygenerowana automatycznie przez GameFlash. Otworz link w karcie, aby przejsc do pelnego artykulu.</td>
+      </tr>
+    </table>
+  </center>
+</body>
+</html>
+"""
 
 
 def send_email(
@@ -14,11 +156,14 @@ def send_email(
     sender_pass: str,
 ):
     """Wysyłka maili"""
-    body = "\n\n".join(news_to_send)
-    msg = MIMEMultipart()
+    plain_body = build_plain_text_body(news_to_send)
+    html_body = build_email_html(news_to_send)
+
+    msg = MIMEMultipart("alternative")
     msg["From"] = sender_mail
-    msg["Subject"] = "Podsumowanie newsów z Eurogamer"
-    msg.attach(MIMEText(body, "plain"))
+    msg["Subject"] = "Podsumowanie newsow z GameFlash"
+    msg.attach(MIMEText(plain_body, "plain", "utf-8"))
+    msg.attach(MIMEText(html_body, "html", "utf-8"))
 
     msg["Bcc"] = ", ".join(recipients)
 

--- a/prd/002-gaming-email-styles-prd.md
+++ b/prd/002-gaming-email-styles-prd.md
@@ -1,0 +1,212 @@
+# PRD 002: Stylowany e-mail HTML dla GameFlash
+
+## Cel zmiany
+
+Celem tej zmiany jest zastąpienie obecnej wiadomości `plain text` estetycznym e-mailem HTML, który lepiej prezentuje podsumowania newsów gamingowych i buduje bardziej dopracowany charakter produktu GameFlash.
+
+Po wdrożeniu GameFlash ma:
+- wysyłać zbiorcze podsumowanie newsów w formacie HTML,
+- zachować kompatybilny fallback `plain text`,
+- prezentować każdy news jako osobną, czytelną sekcję,
+- stosować nowoczesną stylistykę dopasowaną do tematu newsów o grach,
+- pozostać prostym skryptem bez przebudowy całej architektury aplikacji.
+
+Inspiracją implementacyjną jest sposób budowy maila HTML w projekcie `DramaChecker`, ale bez kopiowania jego layoutu i kolorystyki 1:1.
+
+## Problem do rozwiązania
+
+Obecna implementacja:
+- wysyła wiadomość wyłącznie jako `plain text`,
+- skleja podsumowania w jeden blok tekstu,
+- nie eksponuje wyraźnie tytułów, streszczeń i linków,
+- nie buduje wizualnej tożsamości produktu.
+
+To podejście jest niepożądane, ponieważ:
+- czytelność przy większej liczbie newsów jest ograniczona,
+- wiadomość wygląda technicznie i surowo,
+- trudniej szybko przeskanować treść i przejść do interesującego artykułu,
+- forma wiadomości odstaje od jakości, jakiej oczekuje się od nowoczesnego newslettera o grach.
+
+## Zakres funkcjonalny
+
+Zmiana obejmuje:
+- generowanie wiadomości HTML z osadzonym CSS zgodnym z klientami pocztowymi,
+- zachowanie fallbacku `plain text` w wiadomości multipart,
+- prezentowanie każdego newsa jako osobnej karty lub sekcji,
+- dodanie nagłówka z brandingiem `GameFlash`,
+- dodanie krótkiego opisu charakteru wiadomości w sekcji hero,
+- wyeksponowanie w każdej karcie co najmniej:
+  - tytułu,
+  - streszczenia,
+  - linku do pełnego artykułu,
+- dodanie przycisku albo wyraźnego linku CTA do pełnego artykułu,
+- dodanie stopki z krótką informacją systemową,
+- przygotowanie stylu, który pozostaje czytelny zarówno na desktopie, jak i na urządzeniach mobilnych.
+
+## Poza zakresem
+
+Ta zmiana nie obejmuje:
+- zmiany logiki pobierania newsów,
+- zmiany logiki działania Groq,
+- zmiany integracji z Google Sheets,
+- zmiany pobierania treści przez Jina,
+- zmiany deduplikacji linków,
+- zmiany schedulerów, retry ani monitoringu,
+- pełnego redesignu architektury aplikacji,
+- dodawania panelu administracyjnego lub systemu szablonów,
+- osadzania obrazów jako wymogu pierwszej wersji,
+- personalizacji wiadomości per odbiorca.
+
+## Docelowy wygląd i doświadczenie odbiorcy
+
+Docelowy kierunek wizualny:
+- nowoczesny gaming,
+- nowoczesny, wyrazisty, ale czytelny,
+- bliżej newslettera technologiczno-growego niż formalnego raportu systemowego.
+
+Założenia stylistyczne:
+- tło w ciemnych tonach: grafit, granat lub niemal czarne odcienie,
+- akcenty kolorystyczne inspirowane estetyką gamingową, np. neonowy cyan, elektryczny niebieski, limonka lub magenta jako akcent,
+- wyraźny kontrast pomiędzy tłem, kartami i CTA,
+- uniknięcie stylu cukierkowego, pastelowego i korporacyjnie neutralnego,
+- zachowanie wysokiej czytelności tekstu mimo bardziej charakterystycznej oprawy.
+
+Wiadomość ma sprawiać wrażenie:
+- nowoczesnej,
+- dopracowanej,
+- lekkiej wizualnie,
+- łatwej do szybkiego przeskanowania.
+
+## Docelowa struktura wiadomości
+
+Wiadomość HTML ma mieć następującą strukturę:
+
+1. Sekcja hero / header
+- nazwa `GameFlash`,
+- krótki opis, że jest to zestawienie najnowszych newsów gamingowych,
+- wizualnie najmocniejsza sekcja wiadomości.
+
+2. Lista kart newsów
+- każdy news prezentowany jako osobna karta lub wyraźnie wydzielony blok,
+- karta zawiera tytuł, streszczenie i link do pełnego artykułu,
+- CTA powinno być łatwe do kliknięcia także na mobile.
+
+3. Opcjonalny pusty stan
+- jeśli w przyszłości scenariusz wysyłki wiadomości bez newsów zostanie wsparty, wiadomość powinna mieć przewidziany estetyczny pusty stan,
+- ta zmiana ma przygotować taki kierunek w PRD, ale bez wymogu wdrażania dodatkowej logiki biznesowej w tej samej iteracji.
+
+4. Stopka
+- krótka informacja systemowa o pochodzeniu wiadomości,
+- zachowanie prostoty i małej ilości tekstu.
+
+## Wymagania techniczne
+
+Wymagania dla implementacji wynikającej z tego PRD:
+- wiadomość ma być wysyłana jako multipart zawierający `text/plain` oraz `text/html`,
+- HTML ma używać prostego, osadzonego CSS kompatybilnego z typowymi klientami pocztowymi,
+- styl nie może zależeć od zewnętrznych fontów, CDN ani zdalnych plików CSS,
+- pierwsza wersja nie wymaga zewnętrznych obrazów, bannerów ani assetów hostowanych poza wiadomością,
+- układ ma być odporny na podstawowe ograniczenia klientów pocztowych,
+- treść `plain text` ma nadal zawierać komplet informacji potrzebnych odbiorcy.
+
+## Ważne interfejsy i wpływ na implementację
+
+Docelowo ta zmiana ma prowadzić do modyfikacji interfejsu wysyłki z:
+- pojedynczego `plain text` body
+
+na:
+- wiadomość multipart zawierającą `text/plain` oraz `text/html`.
+
+Zmiana ma również wymagać wydzielenia lekkiego renderowania HTML wiadomości, ale bez narzucania nowej architektury aplikacji poza minimum potrzebnym do:
+- zbudowania szablonu HTML,
+- podstawienia danych newsów do sekcji wiadomości,
+- przygotowania spójnego fallbacku tekstowego.
+
+## Decyzje produktowe i techniczne
+
+### 1. Referencja implementacyjna z `DramaChecker`
+
+Decyzja:
+- projekt `DramaChecker` stanowi wzorzec użycia HTML maila i osadzonego CSS, ale nie ma być kopiowany wizualnie 1:1.
+
+Uzasadnienie:
+- w repo istnieje już sprawdzony sposób budowy i wysyłki stylowanego maila,
+- pozwala to ograniczyć ryzyko nietrafionej lub zbyt ciężkiej implementacji.
+
+Konsekwencje:
+- GameFlash zachowuje własną tożsamość wizualną,
+- implementacja może przejąć podejście techniczne bez kopiowania estetyki produktu referencyjnego.
+
+### 2. HTML jako warstwa prezentacji, nie zmiana logiki biznesowej
+
+Decyzja:
+- ta zmiana dotyczy wyłącznie warstwy prezentacji wiadomości i sposobu jej renderowania.
+
+Uzasadnienie:
+- celem jest poprawa jakości odbioru maila, a nie przebudowa pipeline'u przetwarzania newsów.
+
+Konsekwencje:
+- pobieranie, deduplikacja, podsumowanie i wysyłka do wielu odbiorców pozostają funkcjonalnie bez zmian,
+- zakres implementacji pozostaje ograniczony i bezpieczny.
+
+### 3. Fallback `plain text` pozostaje wymagany
+
+Decyzja:
+- nawet po wdrożeniu HTML wiadomość musi zawierać fallback `plain text`.
+
+Uzasadnienie:
+- poprawia to kompatybilność z klientami pocztowymi i scenariuszami ograniczonego renderowania HTML.
+
+Konsekwencje:
+- implementacja nie może ograniczyć się wyłącznie do `text/html`,
+- testy muszą sprawdzać obecność obu wariantów wiadomości.
+
+### 4. Lekki renderer zgodny ze skryptowym charakterem projektu
+
+Decyzja:
+- renderer maila ma pozostać prosty i lekki, adekwatny do obecnego, skryptowego charakteru GameFlash.
+
+Uzasadnienie:
+- projekt nie wymaga pełnego silnika templatingu ani rozbudowanego systemu widoków dla pojedynczego maila.
+
+Konsekwencje:
+- implementacja powinna preferować prosty szablon HTML i minimalną złożoność,
+- ewentualne wydzielenie funkcji renderujących ma służyć czytelności, a nie zmianie architektury.
+
+## Scenariusze akceptacyjne
+
+1. Co najmniej jeden news
+- jeśli dostępny jest co najmniej jeden news, wiadomość HTML renderuje czytelne karty z tytułem, streszczeniem i linkiem do artykułu.
+
+2. Wiele newsów
+- jeśli wiadomość zawiera wiele newsów, układ pozostaje czytelny i łatwy do skanowania na desktopie i mobile.
+
+3. Fallback tekstowy
+- jeśli klient pocztowy nie renderuje HTML, odbiorca nadal otrzymuje komplet informacji w wersji `plain text`.
+
+4. Link CTA
+- każdy news zawiera wyraźny link lub przycisk prowadzący do pełnego artykułu.
+
+5. Brak regresji SMTP
+- zmiana formatu wiadomości nie powoduje regresji w wysyłce do wielu odbiorców.
+
+6. Brak zależności zewnętrznych
+- wiadomość HTML nie wymaga zewnętrznych obrazów, hostowanych stylów ani fontów, aby zachować podstawową jakość prezentacji.
+
+## Testy i scenariusze walidacyjne
+
+Implementacja wynikająca z tego PRD ma zostać pokryta testami, które weryfikują co najmniej:
+- render pojedynczego newsa do HTML,
+- render wielu newsów do HTML,
+- poprawne dołączenie fallbacku `plain text`,
+- obecność kluczowych elementów wiadomości: nagłówek, karta newsa, CTA i stopka,
+- brak zależności od realnego SMTP w testach,
+- zachowanie kompatybilności z dotychczasowym przebiegiem wysyłki.
+
+## Założenia
+
+- nowy mail dotyczy wyłącznie warstwy prezentacji wiadomości,
+- dane wejściowe pozostają oparte o już wygenerowane podsumowania i linki,
+- pierwsza wersja nie wymaga personalizacji per odbiorca,
+- pierwsza wersja nie wymaga osadzonych grafik,
+- nowy styl ma być nowoczesny i gamingowy, ale nadal czytelny w konserwatywnych klientach pocztowych.

--- a/spec.md
+++ b/spec.md
@@ -24,6 +24,14 @@ Planowane rozszerzenie zakresu wynikające z PRD `001-google-sheets-link-store-p
 
 Rozszerzenie z PRD `001-google-sheets-link-store-prd.md` zostalo wdrozone.
 
+Planowane rozszerzenie zakresu wynikające z PRD `002-gaming-email-styles-prd.md`:
+- zastapienie obecnego e-maila `plain text` stylowanym mailem HTML,
+- zachowanie fallbacku `plain text` w wiadomosci multipart,
+- prezentowanie kazdego newsa jako osobnej sekcji lub karty,
+- dostosowanie wygladu wiadomosci do nowoczesnego, gamingowego charakteru produktu.
+
+Rozszerzenie z PRD `002-gaming-email-styles-prd.md` zostalo wdrozone.
+
 ---
 
 ## Zakres funkcjonalny (high-level)
@@ -58,6 +66,18 @@ Docelowy przepływ wynikający z PRD `001-google-sheets-link-store-prd.md`:
 8. Dopiero po udanym append aplikacja pobiera pełną treść artykułu przez `https://r.jina.ai/<link>`.
 9. Aplikacja generuje podsumowania po polsku i wysyła zbiorczy e-mail.
 
+Docelowy przeplyw wynikajacy z PRD `002-gaming-email-styles-prd.md`:
+1. Aplikacja laduje konfiguracje z `.env`.
+2. Aplikacja uwierzytelnia sie do Google Sheets kontem serwisowym.
+3. Aplikacja odczytuje istniejace linki z kolumny `Links`.
+4. Aplikacja pobiera HTML strony listingu newsow bezposrednio ze zrodlowego URL.
+5. Aplikacja wyciaga linki z HTML na podstawie selektora odpowiadajacego biezacemu rokowi i miesiacowi.
+6. Aplikacja usuwa duplikaty z biezacego przebiegu i odrzuca linki obecne juz w Google Sheets.
+7. Kazdy nowy link jest najpierw dopisywany do Google Sheets.
+8. Dopiero po udanym append aplikacja pobiera pelna tresc artykulu przez `https://r.jina.ai/<link>`.
+9. Aplikacja generuje podsumowania po polsku i przygotowuje dwa warianty wiadomosci: `text/plain` oraz `text/html`.
+10. Aplikacja wysyla jeden e-mail multipart, w ktorym HTML stanowi glowna warstwe prezentacji, a `plain text` pozostaje fallbackiem kompatybilnosci.
+
 Czego aplikacja obecnie nie robi:
 - nie waliduje kompleksowo konfiguracji przed startem,
 - nie obsługuje wielu źródeł wejściowych ani wielu modeli,
@@ -80,6 +100,10 @@ Architektura ma postać prostego skryptu orkiestrującego z kilkoma modułami po
 Planowane rozszerzenie komponentów wynikające z PRD `001-google-sheets-link-store-prd.md`:
 - brak dodatkowych nierozliczonych elementow z tego PRD.
 
+Rozszerzenie komponentow wynikajace z PRD `002-gaming-email-styles-prd.md`:
+- `emails/gmail.py` ma skladac wiadomosc multipart z czescia `text/plain` oraz `text/html`,
+- warstwa maili ma zostac rozszerzona o lekki renderer HTML dla stylowanej wiadomosci GameFlash.
+
 2. Przepływ danych między komponentami
 - Wejście konfiguracyjne pochodzi z `.env` i stałych zaszytych w `main.py`.
 - Konfiguracja obejmuje także `GOOGLE_SHEET_ID`, `GOOGLE_SHEET_WORKSHEET` i `GSPREAD_SERVICE_ACCOUNT_FILE`.
@@ -100,6 +124,11 @@ Docelowy przepływ danych wynikający z PRD `001-google-sheets-link-store-prd.md
 - Pełna treść artykułu ma być pobierana przez mirror `https://r.jina.ai/<link>`.
 - Model Groq ma pozostać odpowiedzialny wyłącznie za podsumowanie i korektę tekstu.
 
+Docelowy przeplyw danych wynikajacy z PRD `002-gaming-email-styles-prd.md`:
+- gotowe sekcje podsumowan maja zostac przeksztalcone do dwoch reprezentacji: `plain text` oraz `html`,
+- warstwa HTML ma renderowac kazdy news jako osobny blok z tytulem, streszczeniem i CTA do pelnego artykulu,
+- gotowa wiadomosc ma byc wysylana jako multipart przez SMTP bez zaleznosci od zewnetrznych assetow.
+
 3. Granice odpowiedzialności
 - Logika przepływu pozostaje w `main.py`.
 - Integracje z zewnętrznymi usługami są rozdzielone na moduły `scrapers`, `llms` i `emails`.
@@ -109,6 +138,11 @@ Docelowy przepływ danych wynikający z PRD `001-google-sheets-link-store-prd.md
 Po wdrożeniu PRD `001-google-sheets-link-store-prd.md`:
 - LLM pozostanie wyłącznie komponentem generowania treści.
 - pełna treść artykułów jest pobierana przez mirror Jina.
+
+Po wdrozeniu PRD `002-gaming-email-styles-prd.md`:
+- warstwa maili pozostanie odpowiedzialna za dostarczenie wiadomosci przez SMTP,
+- renderer HTML bedzie odpowiadal wyłącznie za prezentacje wiadomosci,
+- fallback `plain text` pozostanie czescia kontraktu wysylki dla kompatybilnosci.
 
 ---
 
@@ -127,6 +161,11 @@ Lista kluczowych komponentów technicznych i ich odpowiedzialności.
 
 Planowane rozszerzenia techniczne wynikające z PRD `001-google-sheets-link-store-prd.md`:
 - brak dodatkowych zaleznosci wymaganych do domkniecia tego PRD.
+
+Rozszerzenia techniczne wynikajace z PRD `002-gaming-email-styles-prd.md`:
+- wykorzystanie standardowych mechanizmow MIME do zbudowania wiadomosci multipart z `text/plain` i `text/html`,
+- osadzony CSS zgodny z typowymi klientami pocztowymi,
+- brak nowej zaleznosci wykonawczej, o ile prosty renderer HTML da sie zrealizowac w oparciu o standardowa biblioteke lub juz obecne zaleznosci.
 
 ---
 
@@ -186,6 +225,26 @@ Każda decyzja powinna zawierać:
 - Uzasadnienie: zrodlo stanu, ekstrakcja listingu i pobieranie tresci artykulu zostaly doprowadzone do stanu zgodnego z PRD.
 - Konsekwencje: kolejne zmiany moga juz wychodzic od nowego, docelowego pipeline'u, a nie od stanu przejsciowego.
 
+- Decyzja (dotyczy PRD: `002-gaming-email-styles-prd.md`): wysylka maili ma zostac rozszerzona z pojedynczego `plain text` body do wiadomosci multipart zawierajacej `text/plain` oraz `text/html`.
+- Uzasadnienie: pozwala to poprawic prezentacje wiadomosci bez utraty kompatybilnosci z klientami pocztowymi i scenariuszami ograniczonego renderowania HTML.
+- Konsekwencje: interfejs warstwy mailowej bedzie musial przygotowywac dwie reprezentacje tej samej tresci i testowac obie sciezki.
+
+- Decyzja (dotyczy PRD: `002-gaming-email-styles-prd.md`): inspiracja z projektu `DramaChecker` ma dotyczyc techniki budowy maila HTML i osadzonego CSS, ale bez kopiowania layoutu 1:1.
+- Uzasadnienie: w sasiednim projekcie istnieje juz sprawdzony wzorzec techniczny, ktory mozna wykorzystac bez utraty tozsamosci wizualnej GameFlash.
+- Konsekwencje: implementacja moze przejac podejscie do renderowania HTML, ale musi przygotowac osobny styl i kolorystyke dla newsow gamingowych.
+
+- Decyzja (dotyczy PRD: `002-gaming-email-styles-prd.md`): stylowana warstwa HTML ma pozostac lekka, bez zaleznosci od zewnetrznych fontow, CDN, zdalnych stylow i hostowanych obrazow jako wymogu v1.
+- Uzasadnienie: ogranicza to ryzyko problemow z kompatybilnoscia klientow pocztowych i utrzymuje prosty charakter projektu.
+- Konsekwencje: implementacja musi opierac sie na osadzonym CSS i tresci tekstowej, a efekt wizualny bedzie budowany glownie ukladem, kontrastem i kolorystyka.
+
+- Konflikt specyfikacji (dotyczy PRD: `002-gaming-email-styles-prd.md`): brak aktywnego konfliktu na etapie planowania.
+- Uzasadnienie: nowe PRD rozszerza jedynie sposob prezentacji i wysylki wiadomosci, bez zmiany logiki pobierania, deduplikacji i podsumowania newsow.
+- Konsekwencje: nowy przyrost moze zostac zaplanowany jako kolejny milestone po Milestone 1.2 bez rewizji poprzednich decyzji funkcjonalnych.
+
+- Konflikt specyfikacji (dotyczy PRD: `002-gaming-email-styles-prd.md`): brak aktywnego konfliktu po wdrozeniu Milestone 1.3.
+- Uzasadnienie: nowy format maila zostal wdrozony bez zmiany logiki pobierania, deduplikacji i podsumowania newsow.
+- Konsekwencje: kolejne zmiany moga rozwijac warstwe prezentacji maila lub kolejne funkcje produktu bez rewizji poprzedniego pipeline'u.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -214,6 +273,14 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `001-google-sheets-link-sto
 - pelna treść artykułu jest pobierana przez `https://r.jina.ai/<link>`,
 - błąd pobrania lub podsumowania po udanym append nie powoduje ponownego podjęcia linku w kolejnym przebiegu.
 
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-gaming-email-styles-prd.md`:
+- dla co najmniej jednego nowego newsa aplikacja przygotowuje wiadomosc HTML z czytelnymi sekcjami zawierajacymi tytul, streszczenie i link do artykulu,
+- wiadomosc e-mail jest wysylana jako multipart zawierajacy `text/plain` oraz `text/html`,
+- fallback `plain text` nadal zawiera komplet informacji o wszystkich newsach z danego przebiegu,
+- styl HTML nie zalezy od zewnetrznych obrazow, fontow ani zdalnych stylow,
+- uklad wiadomosci pozostaje czytelny przy wielu newsach i na waskich ekranach,
+- zmiana formatu wiadomosci nie wprowadza regresji w wysylce do wielu odbiorcow.
+
 ---
 
 ## Zasady zmian i ewolucji
@@ -229,11 +296,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `001-google-sheets-link-sto
 - Aktualny kod odpowiada etapowi wczesnego, działającego workflow end-to-end, ale nadal nie spełnia wszystkich oczekiwań jakościowych z Milestone 0.5, głównie z powodu braku testów i twardo zakodowanej części konfiguracji.
 - PRD `001-google-sheets-link-store-prd.md` wprowadza kolejny przyrost funkcjonalny: migrację deduplikacji linków do Google Sheets i usunięcie LLM z kroku ekstrakcji linków.
 - Realizacja tego PRD wymaga nowych milestone'ów po Milestone 0.5, obejmujących integrację z Google Sheets, migrację przepływu i domknięcie jakości operacyjnej.
-- Milestone 1.0, 1.1 i 1.2 sa wdrozone, a aktualna roadmapa nie zawiera juz otwartych milestone'ow funkcjonalnych.
+- PRD `002-gaming-email-styles-prd.md` wprowadza kolejny przyrost funkcjonalny: przejscie z maila `plain text` na stylowana wiadomosc HTML z fallbackiem `plain text`.
+- Milestone 1.0, 1.1, 1.2 i 1.3 sa wdrozone, a aktualna roadmapa nie zawiera obecnie otwartych milestone'ow funkcjonalnych.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
 - Ostatnia aktualizacja: 2026-03-22
-- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.2 i domknieciu PRD `001-google-sheets-link-store-prd.md`
+- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.3 i domknieciu PRD `002-gaming-email-styles-prd.md`

--- a/tests/test_milestone_1_3.py
+++ b/tests/test_milestone_1_3.py
@@ -1,0 +1,136 @@
+import email
+import unittest
+
+from emails import gmail
+
+
+class FakeSMTP:
+    last_instance = None
+
+    def __init__(self, host, port, timeout=None):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.sent_messages = []
+        self.logged_in_as = None
+        self.started_tls = False
+        FakeSMTP.last_instance = self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def ehlo(self):
+        return None
+
+    def starttls(self, context=None):
+        self.started_tls = True
+
+    def login(self, user, password):
+        self.logged_in_as = (user, password)
+
+    def sendmail(self, sender, recipients, raw_message):
+        self.sent_messages.append((sender, recipients, raw_message))
+
+
+class MilestoneOneThreeTests(unittest.TestCase):
+    def test_build_email_html_renders_single_news_card(self):
+        html_body = gmail.build_email_html(
+            [
+                "Tytuł: Helldivers 2 dostaje nowy update\n\n"
+                "Podsumowanie: Aktualizacja dodaje nowa bron i poprawki balansu.\n\n"
+                "Link: https://konsolowe.info/2026/03/helldivers-2-update/\n\n"
+                "################################"
+            ]
+        )
+
+        self.assertIn("GameFlash", html_body)
+        self.assertIn("GameFlash News", html_body)
+        self.assertIn("Helldivers 2 dostaje nowy update", html_body)
+        self.assertIn("Czytaj pełny artykuł", html_body)
+        self.assertIn("https://konsolowe.info/2026/03/helldivers-2-update/", html_body)
+        self.assertIn("<style type=\"text/css\">", html_body)
+        self.assertNotIn("Link:", html_body)
+
+    def test_build_email_html_renders_multiple_news_cards(self):
+        html_body = gmail.build_email_html(
+            [
+                "Tytuł: News One\n\nPodsumowanie: Pierwszy opis.\n\nLink: https://example.com/one\n\n################################",
+                "Tytul: News Two\n\nPodsumowanie: Drugi opis.\n\nLink: https://example.com/two\n\n################################",
+            ]
+        )
+
+        self.assertEqual(2, html_body.count("GameFlash News"))
+        self.assertIn("News One", html_body)
+        self.assertIn("News Two", html_body)
+        self.assertIn("https://example.com/one", html_body)
+        self.assertIn("https://example.com/two", html_body)
+        self.assertNotIn("Link:", html_body)
+
+    def test_build_plain_text_body_removes_separators_and_keeps_content(self):
+        plain_body = gmail.build_plain_text_body(
+            [
+                "Tytuł: News One\n\nPodsumowanie: Pierwszy opis.\n\nLink: https://example.com/one\n\n################################",
+                "Tytul: News Two\n\nPodsumowanie: Drugi opis.\n\nLink: https://example.com/two\n\n################################",
+            ]
+        )
+
+        self.assertIn("News One", plain_body)
+        self.assertIn("News Two", plain_body)
+        self.assertIn("https://example.com/one", plain_body)
+        self.assertIn("https://example.com/two", plain_body)
+        self.assertNotIn("################################", plain_body)
+
+    def test_send_email_builds_multipart_message_with_plain_and_html(self):
+        original_smtp = gmail.smtplib.SMTP
+        try:
+            gmail.smtplib.SMTP = FakeSMTP
+
+            gmail.send_email(
+                recipients=["gracz@example.com", "drugi@example.com"],
+                news_to_send=[
+                    "Tytuł: Clair Obscur robi wrazenie\n\n"
+                    "Podsumowanie: Nowy material pokazuje walke i klimat gry.\n\n"
+                    "Link: https://example.com/clair-obscur\n\n"
+                    "################################"
+                ],
+                sender_mail="sender@example.com",
+                smtp_server="smtp.example.com",
+                sender_pass="topsecret",
+            )
+        finally:
+            gmail.smtplib.SMTP = original_smtp
+
+        smtp_instance = FakeSMTP.last_instance
+        self.assertIsNotNone(smtp_instance)
+        self.assertTrue(smtp_instance.started_tls)
+        self.assertEqual(("sender@example.com", "topsecret"), smtp_instance.logged_in_as)
+        self.assertEqual(1, len(smtp_instance.sent_messages))
+
+        sender, recipients, raw_message = smtp_instance.sent_messages[0]
+        self.assertEqual("sender@example.com", sender)
+        self.assertEqual(["gracz@example.com", "drugi@example.com"], recipients)
+
+        parsed_message = email.message_from_string(raw_message)
+        self.assertTrue(parsed_message.is_multipart())
+
+        parts = parsed_message.get_payload()
+        self.assertEqual(2, len(parts))
+        self.assertEqual("text/plain", parts[0].get_content_type())
+        self.assertEqual("text/html", parts[1].get_content_type())
+
+        plain_payload = parts[0].get_payload(decode=True).decode("utf-8")
+        html_payload = parts[1].get_payload(decode=True).decode("utf-8")
+
+        self.assertIn("Clair Obscur robi wrazenie", plain_payload)
+        self.assertIn("https://example.com/clair-obscur", plain_payload)
+        self.assertIn("GameFlash", html_payload)
+        self.assertIn("Czytaj pełny artykuł", html_payload)
+        self.assertIn("https://example.com/clair-obscur", html_payload)
+        self.assertNotIn("Link:", html_payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zakres
- dodanie stylowanego maila HTML dla GameFlash
- zachowanie fallbacku `plain text` w wiadomosci multipart
- testy renderowania i wysylki maila bez realnego SMTP
- aktualizacja PRD i dokumentacji operacyjnej

## Walidacja
- uv run python -m unittest discover -s tests -p "test_*.py"