### PR TITLE
Migrate Groq model to Qwen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Groq API
 GROQ_API_KEY="gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-LLM_MODEL="meta-llama/llama-4-scout-17b-16e-instruct"
+LLM_MODEL="qwen/qwen3.6-27b"
 
 # Google Sheets
 GOOGLE_SHEET_ID="1o0htAcR-8ej4u9GiRCYHxxvFKE7BhCaryB6nqkM-KTI"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skrypt do podsumowywania newsow z branzy gier.
 
 ## Jak to dziala
 
-Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`.
+Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`. Domyslnym modelem jest `qwen/qwen3.6-27b`.
 
 ## Wymagania
 
@@ -18,7 +18,7 @@ Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista k
 1. Skopiuj `.env.example` do `.env`.
 2. Uzupelnij wartosci zmiennych:
    - `GROQ_API_KEY`
-   - `LLM_MODEL`
+   - `LLM_MODEL` (domyslnie `qwen/qwen3.6-27b`)
    - `GOOGLE_SHEET_ID`
    - `GOOGLE_SHEET_WORKSHEET`
    - `GSPREAD_SERVICE_ACCOUNT_FILE`
@@ -50,6 +50,14 @@ uv run python -m unittest discover -s tests -p "test_*.py"
 ```
 
 Testy obejmuja Google Sheets, parser listingu, finalny pipeline przetwarzania linkow w trybie stubowanym oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
+
+Opcjonalna walidacja live modelu Qwen, bez zapisu do Google Sheets i bez wysylki SMTP:
+
+```bash
+RUN_LIVE_GROQ_VALIDATION=1 uv run python -m unittest tests.test_milestone_1_4.QwenLiveValidationTests
+```
+
+Walidacja wymaga `GROQ_API_KEY` w `.env`. Standardowe testy pomijaja ten scenariusz.
 
 ## Przykladowy wynik
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -118,3 +118,30 @@ Zakres:
 - przygotowanie maila multipart z warstwa `text/plain` i `text/html`
 - zaprojektowanie nowoczesnej, gamingowej stylistyki wiadomosci
 - dostosowanie testow jednostkowych i smoke testow do nowego formatu e-maila
+
+---
+
+## Milestone 1.4: Migracja modelu Groq na Qwen 3.6 27B (done)
+
+Cel:
+- zastapic domyslny model `meta-llama/llama-4-scout-17b-16e-instruct` modelem `qwen/qwen3.6-27b`
+- potwierdzic w jednorazowej walidacji live zachowanie oczekiwanego formatu odpowiedzi przez nowy model
+- rozstrzygnac na podstawie testu live, czy potrzebne jest usuwanie blokow `<think>...</think>`
+
+Definition of Done:
+- domyslny fallback `LLM_MODEL` wskazuje `qwen/qwen3.6-27b`
+- konfiguracja przez `LLM_MODEL` nadal pozwala nadpisac model
+- jednorazowa walidacja live nowego modelu nie zapisuje danych do Google Sheets i nie wysyla SMTP
+- wynik walidacji live wskazuje, czy odpowiedz zawiera bloki `<think>...</think>`
+- jesli walidacja live wykaze bloki `<think>...</think>`, aplikacja usuwa je przed dalszym przetwarzaniem i ma testy jednostkowe dla tego zachowania
+- jesli walidacja live nie wykaze blokow `<think>...</think>`, pipeline pozostaje bez dodatkowej sanitizacji
+- normalny pipeline nadal wykonuje dwa wywolania modelu na jeden poprawnie przetworzony news
+- dokumentacja operacyjna opisuje nowy model i sposob walidacji
+- testy lokalne przechodza komenda `uv run python -m unittest discover -s tests -p "test_*.py"`
+
+Zakres:
+- podmiana domyslnej wartosci modelu w konfiguracji aplikacji
+- aktualizacja `.env.example`, README i dokumentacji operacyjnej modelu
+- przygotowanie izolowanej walidacji live na stalej probce artykulu
+- warunkowe dodanie usuwania blokow `<think>...</think>` w odpowiedziach modelu
+- dostosowanie testow jednostkowych do wyniku walidacji live

--- a/STATUS.md
+++ b/STATUS.md
@@ -3,12 +3,12 @@
 ## Co działa
 - Glowny skrypt pobiera newsy, podsumowuje je i wysyla e-mail.
 - Zarzadzanie zaleznosciami zostalo przeniesione na `uv`.
-- Model LLM jest konfigurowany przez `LLM_MODEL` w `.env`.
+- Model LLM jest konfigurowany przez `LLM_MODEL` w `.env`; domyslnym modelem jest `qwen/qwen3.6-27b`.
 - Stan przetworzonych linkow jest odczytywany i zapisywany w Google Sheets.
 - Listing newsow jest parsowany bezposrednio z HTML bez uzycia LLM.
 - Pelna tresc artykulow jest pobierana przez mirror Jina.
 - Wiadomosc e-mail jest wysylana jako multipart z fallbackiem `plain text` i stylowana warstwa HTML.
-- Testy `unittest` dla Milestone 1.0-1.3 przechodza lokalnie.
+- Testy `unittest` dla Milestone 1.0-1.4 przechodza lokalnie.
 
 ## Co jest skończone
 - Dodanie dokumentow operacyjnych repo.
@@ -17,6 +17,7 @@
 - Milestone 1.1: deterministyczna ekstrakcja linkow z HTML.
 - Milestone 1.2: finalny pipeline przetwarzania linkow i obsluga bledow po append.
 - Milestone 1.3: stylowany e-mail HTML dla GameFlash z fallbackiem `plain text`.
+- Milestone 1.4: migracja domyslnego modelu Groq na `qwen/qwen3.6-27b`, walidacja live Qwen i obsluga reasoning.
 - Bazowy zestaw testow `unittest` dla Google Sheets i deduplikacji.
 - Aktualizacja bezposrednich zaleznosci do najnowszych kompatybilnych wersji.
 
@@ -30,6 +31,7 @@
 - Uruchomienie produkcyjne wymaga poprawnie uzupelnionego `.env`.
 - Walidacja live Google Sheets zalezy od dostepu konta serwisowego do wskazanego arkusza.
 - Dalsze powodzenie pipeline'u zalezy od dostepnosci Google Sheets, strony z listingiem, mirroru Jina, Groq i SMTP.
+- Model `qwen/qwen3.6-27b` wymaga ukrycia reasoning i wiekszego budzetu tokenow, aby zwracac finalna tresc zamiast technicznego procesu rozumowania.
 
 ## Ostatnie aktualizacje
 - 2026-03-21: migracja konfiguracji projektu na `uv`.
@@ -38,3 +40,4 @@
 - 2026-03-22: wdrozenie Milestone 1.2, testy lokalne i walidacja live finalnego pipeline'u.
 - 2026-03-22: model LLM przeniesiony do `LLM_MODEL` w `.env` i odswiezone zaleznosci wykonawcze.
 - 2026-03-22: wdrozenie Milestone 1.3, stylowany e-mail HTML, fallback `plain text` i testy lokalne warstwy maili.
+- 2026-06-27: wdrozenie Milestone 1.4, domyslny model `qwen/qwen3.6-27b`, walidacja live Qwen, ukrycie reasoning i testy lokalne.

--- a/llms/groq.py
+++ b/llms/groq.py
@@ -1,6 +1,13 @@
 """Funkcje dotyczące konfigurajic LLM"""
 
+import re
+
 from groq import Groq
+
+QWEN_REASONING_MODEL = "qwen/qwen3.6-27b"
+QWEN_MIN_MAX_TOKENS = 4096
+THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
+OPEN_THINK_BLOCK_RE = re.compile(r"<think>.*\Z", re.DOTALL | re.IGNORECASE)
 
 
 def news_prompt(year: str, month: str, context: str) -> str:
@@ -76,6 +83,12 @@ Link: <link to news item>
     return prompt
 
 
+def sanitize_model_response(response: str) -> str:
+    """Usuwa techniczne bloki reasoning z odpowiedzi modelu."""
+    without_complete_blocks = THINK_BLOCK_RE.sub("", response)
+    return OPEN_THINK_BLOCK_RE.sub("", without_complete_blocks).strip()
+
+
 def groq_client(groq_api_key):
     """Inicjalizacja klienta Groq"""
     client = Groq(
@@ -103,19 +116,31 @@ def run_groq_model(
     groq_api_key: str,
     model: str,
     options: dict,
+    sanitize_response: bool = True,
 ):
     """Uruchomienie LLM do wskazanych zadan z trybem JSON lub nie"""
     client = groq_client(groq_api_key)
-    chat_completion = client.chat.completions.create(
-        model=model,
-        messages=[
+    request_options = {
+        "model": model,
+        "messages": [
             {"role": "user", "content": options["prompt"]},
         ],
-        temperature=options.get("temperature", 1),
-        max_tokens=options.get("max_tokens", 1500),
-        stream=False,
-        stop=None,
-    )
+        "temperature": options.get("temperature", 1),
+        "max_tokens": options.get("max_tokens", 1500),
+        "stream": False,
+        "stop": None,
+    }
+    if model == QWEN_REASONING_MODEL:
+        request_options["reasoning_format"] = "hidden"
+        request_options["max_tokens"] = max(
+            request_options["max_tokens"], QWEN_MIN_MAX_TOKENS
+        )
 
-    model_response = chat_completion.choices[0].message.content
+    chat_completion = client.chat.completions.create(**request_options)
+
+    model_response = chat_completion.choices[0].message.content or ""
+    if sanitize_response:
+        model_response = sanitize_model_response(model_response)
+    if not model_response.strip():
+        raise RuntimeError("Model zwrocil pusta odpowiedz.")
     return model_response

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Głowny plik skryptu"""
 
 import os
+import re
 from dotenv import load_dotenv
 
 from llms import groq
@@ -8,6 +9,9 @@ from scrapers import jina, listing
 from emails import gmail
 from storage import google_sheets
 from utils import utils
+
+DEFAULT_LLM_MODEL = "qwen/qwen3.6-27b"
+LINK_RE = re.compile(r"^Link:\s*(\S+)\s*$", re.MULTILINE)
 
 
 def load_config():
@@ -18,9 +22,7 @@ def load_config():
     return {
         "URL": "https://konsolowe.info/playstation/ps5/",
         "GROQ_API": os.getenv("GROQ_API_KEY"),
-        "LLM_MODEL": os.getenv(
-            "LLM_MODEL", "meta-llama/llama-4-scout-17b-16e-instruct"
-        ),
+        "LLM_MODEL": os.getenv("LLM_MODEL", DEFAULT_LLM_MODEL),
         "SMTP_SERVER": os.getenv("SMTP_SERVER"),
         "SENDER_MAIL": os.getenv("SENDER_MAIL"),
         "SENDER_PASS": os.getenv("SENDER_PASS"),
@@ -97,6 +99,18 @@ def summarize_news(config, new_links):
     return news_to_corrected
 
 
+def ensure_link_in_proofreading_result(proofreading_news: str, source_news: str) -> str:
+    """Zachowuje link z wejscia, jesli model pominie go w korekcie."""
+    if LINK_RE.search(proofreading_news):
+        return proofreading_news
+
+    link_match = LINK_RE.search(source_news)
+    if not link_match:
+        return proofreading_news
+
+    return f"{proofreading_news.rstrip()}\n\nLink: {link_match.group(1)}"
+
+
 def news_proofreading(config, news_to_corrected):
     """Przeprowadza korektę na podsumowanych newsach"""
     news_to_send = []
@@ -111,6 +125,9 @@ def news_proofreading(config, news_to_corrected):
                 groq_api_key=config["GROQ_API"],
                 model=config["LLM_MODEL"],
                 options=proofreading_model_options,
+            )
+            proofreading_news = ensure_link_in_proofreading_result(
+                proofreading_news, news
             )
         except Exception as exc:
             print(f"Nie udalo sie wykonac korekty newsa: {exc}")

--- a/prd/003-qwen-model-migration-prd.md
+++ b/prd/003-qwen-model-migration-prd.md
@@ -1,0 +1,197 @@
+# PRD 003: Migracja modelu Groq na Qwen 3.6 27B
+
+## Cel zmiany
+
+Celem tej zmiany jest zastąpienie obecnie używanego modelu Groq `meta-llama/llama-4-scout-17b-16e-instruct` modelem `qwen/qwen3.6-27b`, ponieważ obecny model ma zostać wyłączony w lipcu 2026.
+
+Po wdrożeniu GameFlash ma:
+- domyślnie używać modelu `qwen/qwen3.6-27b`,
+- nadal pozwalać na nadpisanie modelu przez zmienną środowiskową `LLM_MODEL`,
+- zachować obecny przepływ generowania podsumowań i korekty językowej,
+- zweryfikować, czy nowy model zwraca bloki rozumowania w formacie `<think>...</think>`,
+- mieć potwierdzoną jednorazową walidację live nowego modelu przed pełną podmianą.
+
+## Problem do rozwiązania
+
+Obecna implementacja:
+- używa domyślnego modelu `meta-llama/llama-4-scout-17b-16e-instruct`,
+- wykonuje dwa wywołania modelu dla każdego nowego newsa:
+  - generowanie podsumowania,
+  - korektę językową,
+- nie posiada warstwy czyszczenia odpowiedzi modelu z bloków rozumowania.
+
+To podejście jest ryzykowne, ponieważ:
+- obecny domyślny model ma zostać wycofany,
+- po dacie wyłączenia aplikacja może przestać działać bez zmiany konfiguracji,
+- nowy model `qwen/qwen3.6-27b` jest modelem rozumującym i może zwracać techniczne bloki `<think>...</think>`,
+- treści rozumowania nie powinny trafiać do korekty, maila HTML ani fallbacku `plain text`.
+
+## Zakres funkcjonalny
+
+Zmiana obejmuje:
+- podmianę domyślnej wartości modelu na `qwen/qwen3.6-27b`,
+- aktualizację przykładowej konfiguracji `.env.example`,
+- aktualizację dokumentacji operacyjnej opisującej `LLM_MODEL`,
+- przygotowanie jednorazowego testu live nowego modelu,
+- podjęcie decyzji o lokalnej sanitizacji odpowiedzi modelu na podstawie wyniku testu live,
+- dodanie sanitizacji i testów jednostkowych dla usuwania bloków `<think>...</think>` tylko wtedy, gdy test live wykaże taki problem.
+
+## Poza zakresem
+
+Ta zmiana nie obejmuje:
+- zmiany providera LLM,
+- zmiany liczby wywołań modelu dla pojedynczego newsa,
+- przebudowy promptów poza minimalnym dostosowaniem, jeśli test live pokaże taką potrzebę,
+- zmiany logiki pobierania linków,
+- zmiany integracji z Google Sheets,
+- zmiany pobierania treści przez Jina,
+- zmiany wysyłki SMTP i renderowania maila HTML,
+- uruchamiania testu live dla każdego artykułu w normalnym przebiegu aplikacji.
+
+## Docelowy przepływ
+
+Normalny przebieg aplikacji po wdrożeniu pozostaje taki sam funkcjonalnie:
+
+1. Aplikacja ładuje konfigurację z `.env`.
+2. Aplikacja wykrywa nowe linki na listingu.
+3. Aplikacja zapisuje nowe linki do Google Sheets.
+4. Aplikacja pobiera treść artykułu przez Jina.
+5. Aplikacja wywołuje model `qwen/qwen3.6-27b` do wygenerowania podsumowania.
+6. Jeśli test live wykazał problem z blokami `<think>...</think>`, aplikacja usuwa je z odpowiedzi.
+7. Aplikacja wywołuje model `qwen/qwen3.6-27b` do korekty językowej.
+8. Jeśli test live wykazał problem z blokami `<think>...</think>`, aplikacja usuwa je z odpowiedzi.
+9. Aplikacja wysyła e-mail multipart ze stylowanym HTML i fallbackiem `plain text`.
+
+Liczba wywołań modelu dla jednego poprawnie przetworzonego newsa pozostaje bez zmian:
+- 1 wywołanie dla podsumowania,
+- 1 wywołanie dla korekty.
+
+## Jednorazowa walidacja live
+
+Przed pełną podmianą modelu implementacja ma umożliwić jednorazową walidację live nowego modelu.
+
+Walidacja live ma:
+- użyć modelu `qwen/qwen3.6-27b`,
+- użyć jednego stałego, reprezentatywnego artykułu z `konsolowe.info`,
+- pobrać treść artykułu przez Jina albo użyć równoważnej stałej próbki tekstu, jeśli test live ma być izolowany od dostępności strony,
+- wykonać ścieżkę podsumowania i korekty,
+- nie zapisywać niczego do Google Sheets,
+- nie wysyłać e-maila,
+- nie być wykonywana automatycznie dla każdego newsa w normalnym pipeline.
+
+Kryteria zaliczenia walidacji live:
+- odpowiedź zawiera tytuł,
+- odpowiedź zawiera podsumowanie,
+- odpowiedź zawiera link do artykułu na etapie danych gotowych do maila,
+- tekst jest po polsku,
+- wynik testu jasno wskazuje, czy w odpowiedzi pojawia się `<think>` lub `</think>`,
+- wynik nadaje się do użycia w obecnym mailu GameFlash bez ręcznej korekty.
+
+## Wymagania techniczne
+
+### 1. Domyślny model
+
+Decyzja:
+- domyślny fallback `LLM_MODEL` w kodzie ma zostać zmieniony na `qwen/qwen3.6-27b`.
+
+Uzasadnienie:
+- obecny domyślny model ma zostać wyłączony,
+- aplikacja powinna działać poprawnie po aktualizacji bez wymagania ręcznej zmiany domyślnej wartości w kodzie.
+
+Konsekwencje:
+- użytkownik nadal może wskazać inny model przez `.env`,
+- dokumentacja musi pokazywać `qwen/qwen3.6-27b` jako rekomendowaną wartość.
+
+### 2. Zachowanie konfiguracji `LLM_MODEL`
+
+Decyzja:
+- nie usuwamy zmiennej `LLM_MODEL`.
+
+Uzasadnienie:
+- zachowanie konfiguracji pozwala awaryjnie przełączyć model bez zmiany kodu,
+- obecna architektura już wspiera ten mechanizm.
+
+Konsekwencje:
+- podmiana modelu ma być zmianą domyślnej wartości i dokumentacji, a nie usztywnieniem aplikacji na jeden model.
+
+### 3. Obsługa reasoning
+
+Decyzja:
+- reasoning modelu może pozostać aktywny,
+- aplikacja ma najpierw sprawdzić w teście live, czy model zwraca bloki `<think>...</think>`.
+
+Uzasadnienie:
+- `qwen/qwen3.6-27b` jest modelem rozumującym,
+- nie należy dodawać dodatkowej logiki czyszczenia, jeśli model w praktyce zwraca wyłącznie finalną odpowiedź,
+- mail do odbiorcy nie powinien zawierać technicznych bloków rozumowania.
+
+Konsekwencje:
+- jeśli test live nie wykaże obecności `<think>...</think>`, sanitizacja nie jest wymagana w tym przyroście,
+- jeśli test live wykaże obecność `<think>...</think>`, implementacja musi dodać lokalne usuwanie tych bloków i pokryć je testami.
+
+### 4. Decyzja po teście live
+
+Decyzja:
+- test live rozstrzyga, czy sanitizacja jest potrzebna.
+
+Zachowanie:
+- jeśli test live nie pokaże bloków `<think>...</think>`, implementacja ogranicza się do podmiany modelu i dokumentacji,
+- jeśli test live pokaże bloki `<think>...</think>`, implementacja dodaje usuwanie tych bloków po odpowiedzi modelu,
+- w wariancie z sanitizacją czyszczenie dotyczy zarówno podsumowania, jak i korekty,
+- do maila HTML i `plain text` nie może trafić widoczny blok reasoning, jeśli taki blok pojawi się w odpowiedzi modelu.
+
+## Scenariusze akceptacyjne
+
+1. Domyślny model
+- jeśli `LLM_MODEL` nie jest ustawiony w `.env`, aplikacja używa `qwen/qwen3.6-27b`.
+
+2. Nadpisanie modelu przez `.env`
+- jeśli `LLM_MODEL` jest ustawiony, aplikacja używa wartości ze środowiska.
+
+3. Odpowiedź z blokiem `<think>`
+- jeśli test live wykaże, że model zwraca tekst zawierający `<think>...</think>`, implementacja usuwa taki blok przed kolejnym etapem i e-mailem.
+
+4. Odpowiedź bez bloku `<think>`
+- jeśli test live pokaże standardową odpowiedź bez reasoning, aplikacja zachowuje dotychczasowy przepływ bez dodawania sanitizacji.
+
+5. Podsumowanie
+- po wywołaniu modelu dla artykułu wynik podsumowania jest przekazywany dalej bez bloków `<think>...</think>`, jeśli test live wykazał potrzebę ich usuwania.
+
+6. Korekta
+- po wywołaniu modelu dla korekty wynik jest dodawany do listy newsów bez bloków `<think>...</think>`, jeśli test live wykazał potrzebę ich usuwania.
+
+7. Test live
+- walidacja live nowego modelu może zostać uruchomiona ręcznie lub jako osobny test diagnostyczny,
+- walidacja live nie zapisuje danych w Google Sheets,
+- walidacja live nie wysyła wiadomości SMTP.
+
+8. Brak regresji liczby wywołań
+- normalny pipeline nadal wykonuje dwa wywołania modelu na jeden poprawnie przetworzony news.
+
+## Testy i scenariusze walidacyjne
+
+Implementacja wynikająca z tego PRD ma zostać pokryta testami, które weryfikują co najmniej:
+- domyślną wartość modelu `qwen/qwen3.6-27b`,
+- możliwość nadpisania modelu przez `LLM_MODEL`,
+- scenariusz testu live, który raportuje obecność albo brak bloków `<think>...</think>`,
+- usuwanie pojedynczego bloku `<think>...</think>`, jeśli test live wykaże taki problem,
+- usuwanie bloku reasoning poprzedzającego finalną odpowiedź, jeśli test live wykaże taki problem,
+- brak zmian dla odpowiedzi bez bloku reasoning,
+- brak `<think>` w danych przekazywanych do maila, jeśli sanitizacja zostanie wdrożona,
+- brak realnego SMTP w testach jednostkowych,
+- brak realnego zapisu do Google Sheets w testach walidacyjnych.
+
+Standardowa komenda testów pozostaje:
+
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"
+```
+
+## Założenia
+
+- `qwen/qwen3.6-27b` jest docelowym modelem wskazanym dla GameFlash.
+- Test live jest jednorazową walidacją przed wdrożeniem podmiany modelu, a nie elementem normalnego przetwarzania każdego artykułu.
+- Normalny pipeline nadal używa modelu wyłącznie na etapach podsumowania i korekty.
+- Bloki `<think>...</think>` są treścią techniczną i nie powinny być widoczne dla odbiorcy maila, jeśli nowy model zacznie je zwracać.
+- Aktualna architektura z `LLM_MODEL` pozostaje właściwa i nie wymaga przebudowy.
+- Ta zmiana nie rozwiązuje innych problemów jakościowych promptów ani konfiguracji aplikacji.

--- a/spec.md
+++ b/spec.md
@@ -32,6 +32,14 @@ Planowane rozszerzenie zakresu wynikające z PRD `002-gaming-email-styles-prd.md
 
 Rozszerzenie z PRD `002-gaming-email-styles-prd.md` zostalo wdrozone.
 
+Planowane rozszerzenie zakresu wynikające z PRD `003-qwen-model-migration-prd.md`:
+- zastapienie domyslnego modelu Groq modelem `qwen/qwen3.6-27b`,
+- zachowanie mozliwosci nadpisania modelu przez `LLM_MODEL`,
+- wykonanie jednorazowej walidacji live nowego modelu przed pelna podmiana,
+- warunkowe dodanie usuwania blokow `<think>...</think>` tylko wtedy, gdy test live wykaze taki problem.
+
+Rozszerzenie z PRD `003-qwen-model-migration-prd.md` zostalo wdrozone.
+
 ---
 
 ## Zakres funkcjonalny (high-level)
@@ -78,6 +86,15 @@ Docelowy przeplyw wynikajacy z PRD `002-gaming-email-styles-prd.md`:
 9. Aplikacja generuje podsumowania po polsku i przygotowuje dwa warianty wiadomosci: `text/plain` oraz `text/html`.
 10. Aplikacja wysyla jeden e-mail multipart, w ktorym HTML stanowi glowna warstwe prezentacji, a `plain text` pozostaje fallbackiem kompatybilnosci.
 
+Docelowy przeplyw wynikajacy z PRD `003-qwen-model-migration-prd.md`:
+1. Przed podmiana modelu aplikacja przechodzi jednorazowa walidacje live modelu `qwen/qwen3.6-27b` na stalej probce artykulu.
+2. Walidacja live nie zapisuje danych do Google Sheets i nie wysyla e-maila.
+3. Wynik walidacji wskazuje, czy model zwraca bloki `<think>...</think>`.
+4. Jesli walidacja live nie wykaze blokow `<think>...</think>`, implementacja ogranicza sie do podmiany domyslnego modelu i dokumentacji.
+5. Jesli walidacja live wykaze bloki `<think>...</think>`, aplikacja usuwa takie bloki po odpowiedzi modelu przed dalszym przetwarzaniem.
+6. Normalny pipeline nadal wykonuje dwa wywolania modelu na poprawnie przetworzony news: podsumowanie i korekte.
+7. Aplikacja nadal wysyla jeden e-mail multipart z gotowymi podsumowaniami.
+
 Czego aplikacja obecnie nie robi:
 - nie waliduje kompleksowo konfiguracji przed startem,
 - nie obsługuje wielu źródeł wejściowych ani wielu modeli,
@@ -104,6 +121,11 @@ Rozszerzenie komponentow wynikajace z PRD `002-gaming-email-styles-prd.md`:
 - `emails/gmail.py` ma skladac wiadomosc multipart z czescia `text/plain` oraz `text/html`,
 - warstwa maili ma zostac rozszerzona o lekki renderer HTML dla stylowanej wiadomosci GameFlash.
 
+Planowane rozszerzenie komponentow wynikajace z PRD `003-qwen-model-migration-prd.md`:
+- `llms/groq.py` pozostaje miejscem integracji z modelem Groq,
+- konfiguracja modelu ma wskazywac domyslnie `qwen/qwen3.6-27b`,
+- ewentualna warstwa usuwania blokow `<think>...</think>` ma zostac dodana tylko wtedy, gdy test live wykaze taka potrzebe.
+
 2. Przepływ danych między komponentami
 - Wejście konfiguracyjne pochodzi z `.env` i stałych zaszytych w `main.py`.
 - Konfiguracja obejmuje także `GOOGLE_SHEET_ID`, `GOOGLE_SHEET_WORKSHEET` i `GSPREAD_SERVICE_ACCOUNT_FILE`.
@@ -129,6 +151,13 @@ Docelowy przeplyw danych wynikajacy z PRD `002-gaming-email-styles-prd.md`:
 - warstwa HTML ma renderowac kazdy news jako osobny blok z tytulem, streszczeniem i CTA do pelnego artykulu,
 - gotowa wiadomosc ma byc wysylana jako multipart przez SMTP bez zaleznosci od zewnetrznych assetow.
 
+Docelowy przeplyw danych wynikajacy z PRD `003-qwen-model-migration-prd.md`:
+- `LLM_MODEL` pozostaje konfigurowalnym wskazaniem modelu,
+- domyslna wartosc modelu ma zostac zmieniona na `qwen/qwen3.6-27b`,
+- test live ma uzyc stalej probki artykulu i nie moze modyfikowac stanu Google Sheets ani wysylac SMTP,
+- walidacja live wykazala, ze surowa odpowiedz Qwen moze zawierac bloki `<think>...</think>`, dlatego odpowiedzi modelu sa zabezpieczone przed przekazaniem reasoning do korekty i warstwy maili,
+- wywolania Qwen uzywaja ukrytego reasoning oraz lokalnej sanitizacji jako zabezpieczenia.
+
 3. Granice odpowiedzialności
 - Logika przepływu pozostaje w `main.py`.
 - Integracje z zewnętrznymi usługami są rozdzielone na moduły `scrapers`, `llms` i `emails`.
@@ -143,6 +172,11 @@ Po wdrozeniu PRD `002-gaming-email-styles-prd.md`:
 - warstwa maili pozostanie odpowiedzialna za dostarczenie wiadomosci przez SMTP,
 - renderer HTML bedzie odpowiadal wyłącznie za prezentacje wiadomosci,
 - fallback `plain text` pozostanie czescia kontraktu wysylki dla kompatybilnosci.
+
+Po wdrozeniu PRD `003-qwen-model-migration-prd.md`:
+- warstwa LLM pozostanie odpowiedzialna wylacznie za podsumowanie i korekte tekstu,
+- liczba wywolan modelu w normalnym pipeline pozostanie bez zmian,
+- test live nowego modelu pozostanie czynnoscia walidacyjna, a nie etapem przetwarzania kazdego artykulu.
 
 ---
 
@@ -166,6 +200,19 @@ Rozszerzenia techniczne wynikajace z PRD `002-gaming-email-styles-prd.md`:
 - wykorzystanie standardowych mechanizmow MIME do zbudowania wiadomosci multipart z `text/plain` i `text/html`,
 - osadzony CSS zgodny z typowymi klientami pocztowymi,
 - brak nowej zaleznosci wykonawczej, o ile prosty renderer HTML da sie zrealizowac w oparciu o standardowa biblioteke lub juz obecne zaleznosci.
+
+Planowane rozszerzenia techniczne wynikajace z PRD `003-qwen-model-migration-prd.md`:
+- zmiana domyslnej wartosci `LLM_MODEL` na `qwen/qwen3.6-27b`,
+- przygotowanie jednorazowej walidacji live modelu bez zapisu do Google Sheets i bez wysylki SMTP,
+- warunkowe dodanie lokalnego usuwania blokow `<think>...</think>`, jesli walidacja live wykaze taka potrzebe,
+- brak nowych zaleznosci wykonawczych, o ile walidacja i ewentualna sanitizacja moga zostac zrealizowane obecnym stosem.
+
+Rozszerzenia techniczne po wdrozeniu PRD `003-qwen-model-migration-prd.md`:
+- domyslna wartosc `LLM_MODEL` zostala zmieniona na `qwen/qwen3.6-27b`,
+- dla modelu `qwen/qwen3.6-27b` wywolanie Groq ukrywa reasoning w odpowiedzi zwracanej do aplikacji,
+- odpowiedzi modelu sa dodatkowo czyszczone z kompletnych blokow `<think>...</think>` jako zabezpieczenie,
+- dla modelu `qwen/qwen3.6-27b` minimalny budzet `max_tokens` zostal podniesiony, aby reasoning nie zuzywal calego limitu przed finalna odpowiedzia,
+- wynik korekty jest zabezpieczony przed utrata linku: jesli model pominie `Link:`, aplikacja dopisuje link z wejscia.
 
 ---
 
@@ -245,6 +292,26 @@ Każda decyzja powinna zawierać:
 - Uzasadnienie: nowy format maila zostal wdrozony bez zmiany logiki pobierania, deduplikacji i podsumowania newsow.
 - Konsekwencje: kolejne zmiany moga rozwijac warstwe prezentacji maila lub kolejne funkcje produktu bez rewizji poprzedniego pipeline'u.
 
+- Decyzja (dotyczy PRD: `003-qwen-model-migration-prd.md`): domyslnym modelem Groq ma zostac `qwen/qwen3.6-27b`, przy zachowaniu mozliwosci nadpisania przez `LLM_MODEL`.
+- Uzasadnienie: dotychczasowy model `meta-llama/llama-4-scout-17b-16e-instruct` ma zostac wycofany, a zachowanie `LLM_MODEL` pozwala awaryjnie zmienic model bez edycji kodu.
+- Konsekwencje: dokumentacja i przykladowa konfiguracja musza wskazywac nowy model jako rekomendowana wartosc.
+
+- Decyzja (dotyczy PRD: `003-qwen-model-migration-prd.md`): przed pelna podmiana modelu ma zostac wykonana jednorazowa walidacja live modelu `qwen/qwen3.6-27b`.
+- Uzasadnienie: nowy model jest modelem rozumujacym i trzeba sprawdzic, czy zachowuje oczekiwany format odpowiedzi dla podsumowania i korekty.
+- Konsekwencje: walidacja live nie moze byc czescia normalnego pipeline'u dla kazdego artykulu, nie moze zapisywac danych do Google Sheets i nie moze wysylac SMTP.
+
+- Decyzja (dotyczy PRD: `003-qwen-model-migration-prd.md`): usuwanie blokow `<think>...</think>` ma zostac dodane tylko wtedy, gdy walidacja live wykaze, ze nowy model zwraca takie bloki.
+- Uzasadnienie: nie nalezy dodawac dodatkowej logiki czyszczenia, jesli model w praktyce zwraca tylko finalna odpowiedz w oczekiwanym formacie.
+- Konsekwencje: implementacja musi udokumentowac wynik walidacji i albo dodac sanitizacje z testami, albo pozostawic pipeline bez dodatkowego czyszczenia.
+
+- Konflikt specyfikacji (dotyczy PRD: `003-qwen-model-migration-prd.md`): brak aktywnego konfliktu na etapie planowania.
+- Uzasadnienie: PRD zmienia domyslny model i wprowadza walidacje ryzyka reasoning, ale nie zmienia zrodla danych, deduplikacji, liczby wywolan modelu ani wysylki maili.
+- Konsekwencje: przyrost moze zostac zaplanowany jako kolejny milestone po Milestone 1.3.
+
+- Konflikt specyfikacji (dotyczy PRD: `003-qwen-model-migration-prd.md`): brak aktywnego konfliktu po wdrozeniu Milestone 1.4.
+- Uzasadnienie: migracja modelu zostala wdrozona bez zmiany liczby wywolan modelu, zrodla danych, deduplikacji i wysylki maili.
+- Konsekwencje: kolejne zmiany moga rozwijac jakosc promptow lub walidacje konfiguracji bez rewizji decyzji o modelu domyslnym.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -281,6 +348,15 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-gaming-email-styles-pr
 - uklad wiadomosci pozostaje czytelny przy wielu newsach i na waskich ekranach,
 - zmiana formatu wiadomosci nie wprowadza regresji w wysylce do wielu odbiorcow.
 
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `003-qwen-model-migration-prd.md`:
+- aplikacja domyslnie uzywa modelu `qwen/qwen3.6-27b`, jesli `LLM_MODEL` nie zostal ustawiony,
+- `LLM_MODEL` nadal pozwala nadpisac domyslny model,
+- jednorazowa walidacja live nowego modelu sprawdza format odpowiedzi, jezyk polski oraz obecnosc albo brak blokow `<think>...</think>`,
+- walidacja live nie zapisuje linkow do Google Sheets i nie wysyla e-maila,
+- jesli walidacja live wykaze bloki `<think>...</think>`, implementacja usuwa je przed dalszym przetwarzaniem i pokrywa testami,
+- jesli walidacja live nie wykaze blokow `<think>...</think>`, pipeline nie otrzymuje dodatkowej sanitizacji,
+- normalny pipeline nadal wykonuje dwa wywolania modelu na poprawnie przetworzony news.
+
 ---
 
 ## Zasady zmian i ewolucji
@@ -297,11 +373,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `002-gaming-email-styles-pr
 - PRD `001-google-sheets-link-store-prd.md` wprowadza kolejny przyrost funkcjonalny: migrację deduplikacji linków do Google Sheets i usunięcie LLM z kroku ekstrakcji linków.
 - Realizacja tego PRD wymaga nowych milestone'ów po Milestone 0.5, obejmujących integrację z Google Sheets, migrację przepływu i domknięcie jakości operacyjnej.
 - PRD `002-gaming-email-styles-prd.md` wprowadza kolejny przyrost funkcjonalny: przejscie z maila `plain text` na stylowana wiadomosc HTML z fallbackiem `plain text`.
-- Milestone 1.0, 1.1, 1.2 i 1.3 sa wdrozone, a aktualna roadmapa nie zawiera obecnie otwartych milestone'ow funkcjonalnych.
+- PRD `003-qwen-model-migration-prd.md` wprowadza kolejny przyrost funkcjonalny: migracje domyslnego modelu Groq na `qwen/qwen3.6-27b` wraz z walidacja live ryzyka reasoning.
+- Milestone 1.0, 1.1, 1.2, 1.3 i 1.4 sa wdrozone.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
-- Ostatnia aktualizacja: 2026-03-22
-- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.3 i domknieciu PRD `002-gaming-email-styles-prd.md`
+- Ostatnia aktualizacja: 2026-06-27
+- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.4 i domknieciu PRD `003-qwen-model-migration-prd.md`

--- a/tests/test_milestone_1_4.py
+++ b/tests/test_milestone_1_4.py
@@ -1,0 +1,209 @@
+import os
+from types import SimpleNamespace
+import unittest
+
+import main
+from llms import groq
+
+
+QWEN_MODEL = "qwen/qwen3.6-27b"
+VALIDATION_ARTICLE_URL = (
+    "https://konsolowe.info/2024/10/oto-lista-wszystkich-gier-ulepszonych-na-ps5-pro/"
+)
+VALIDATION_ARTICLE_TEXT = """
+Sony opublikowalo liste gier, ktore otrzymaja ulepszenia dla PlayStation 5 Pro.
+Na liscie znalazly sie produkcje first-party oraz gry zewnetrznych wydawcow.
+Aktualizacje maja poprawic jakosc obrazu, plynnosc animacji i wykorzystac nowe
+mozliwosci konsoli, w tym PSSR. Dla graczy oznacza to lepsza oprawe bez
+koniecznosci kupowania osobnych wersji gier.
+"""
+
+
+class MilestoneOneFourTests(unittest.TestCase):
+    def setUp(self):
+        self.original_load_dotenv = main.load_dotenv
+        self.original_llm_model = os.environ.get("LLM_MODEL")
+        self.original_recipients = os.environ.get("RECIPIENTS")
+
+    def tearDown(self):
+        main.load_dotenv = self.original_load_dotenv
+        if self.original_llm_model is None:
+            os.environ.pop("LLM_MODEL", None)
+        else:
+            os.environ["LLM_MODEL"] = self.original_llm_model
+        if self.original_recipients is None:
+            os.environ.pop("RECIPIENTS", None)
+        else:
+            os.environ["RECIPIENTS"] = self.original_recipients
+
+    def test_load_config_uses_qwen_as_default_model(self):
+        main.load_dotenv = lambda: None
+        os.environ.pop("LLM_MODEL", None)
+        os.environ["RECIPIENTS"] = "receiver@example.com"
+
+        config = main.load_config()
+
+        self.assertEqual(QWEN_MODEL, config["LLM_MODEL"])
+
+    def test_load_config_allows_model_override(self):
+        main.load_dotenv = lambda: None
+        os.environ["LLM_MODEL"] = "custom/model"
+        os.environ["RECIPIENTS"] = "receiver@example.com"
+
+        config = main.load_config()
+
+        self.assertEqual("custom/model", config["LLM_MODEL"])
+
+    def test_sanitize_model_response_removes_think_block(self):
+        response = (
+            "<think>analiza techniczna, ktora nie powinna trafic do maila</think>\n"
+            "Tytuł: News\n\nPodsumowanie: Gotowy tekst."
+        )
+
+        sanitized = groq.sanitize_model_response(response)
+
+        self.assertEqual("Tytuł: News\n\nPodsumowanie: Gotowy tekst.", sanitized)
+        self.assertNotIn("<think>", sanitized)
+        self.assertNotIn("</think>", sanitized)
+
+    def test_sanitize_model_response_removes_unclosed_think_block(self):
+        response = (
+            "Tytuł: News\n\nPodsumowanie: Gotowy tekst.\n\n"
+            "<think>uciety proces rozumowania"
+        )
+
+        sanitized = groq.sanitize_model_response(response)
+
+        self.assertEqual("Tytuł: News\n\nPodsumowanie: Gotowy tekst.", sanitized)
+        self.assertNotIn("<think>", sanitized)
+
+    def test_sanitize_model_response_keeps_response_without_think_unchanged(self):
+        response = "Tytuł: News\n\nPodsumowanie: Gotowy tekst."
+
+        self.assertEqual(response, groq.sanitize_model_response(response))
+
+    def test_qwen_request_hides_reasoning_and_uses_minimum_token_budget(self):
+        captured_request = {}
+        original_client = groq.groq_client
+
+        def fake_create(**kwargs):
+            captured_request.update(kwargs)
+            message = SimpleNamespace(content="Tytuł: News\n\nPodsumowanie: Gotowe.")
+            choice = SimpleNamespace(message=message)
+            return SimpleNamespace(choices=[choice])
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        )
+
+        try:
+            groq.groq_client = lambda _: fake_client
+            result = groq.run_groq_model(
+                groq_api_key="test",
+                model=QWEN_MODEL,
+                options=groq.model_options(
+                    prompt="prompt",
+                    temperature=0.8,
+                    max_tokens=1024,
+                ),
+            )
+        finally:
+            groq.groq_client = original_client
+
+        self.assertEqual("Tytuł: News\n\nPodsumowanie: Gotowe.", result)
+        self.assertEqual("hidden", captured_request["reasoning_format"])
+        self.assertEqual(groq.QWEN_MIN_MAX_TOKENS, captured_request["max_tokens"])
+
+    def test_run_groq_model_raises_clear_error_for_empty_content(self):
+        original_client = groq.groq_client
+
+        def fake_create(**kwargs):
+            message = SimpleNamespace(content=None)
+            choice = SimpleNamespace(message=message)
+            return SimpleNamespace(choices=[choice])
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create))
+        )
+
+        try:
+            groq.groq_client = lambda _: fake_client
+            with self.assertRaisesRegex(RuntimeError, "pusta odpowiedz"):
+                groq.run_groq_model(
+                    groq_api_key="test",
+                    model=QWEN_MODEL,
+                    options=groq.model_options(
+                        prompt="prompt",
+                        temperature=0.8,
+                        max_tokens=1024,
+                    ),
+                )
+        finally:
+            groq.groq_client = original_client
+
+    def test_proofreading_keeps_source_link_when_model_omits_it(self):
+        source_news = (
+            "Tytuł: News\n\n"
+            "Podsumowanie: Szkic.\n\n"
+            f"Link: {VALIDATION_ARTICLE_URL}\n\n"
+            "################################"
+        )
+        proofreading_news = "Tytuł: News\n\nPodsumowanie: Gotowy tekst."
+
+        result = main.ensure_link_in_proofreading_result(proofreading_news, source_news)
+
+        self.assertIn(f"Link: {VALIDATION_ARTICLE_URL}", result)
+
+
+@unittest.skipUnless(
+    os.environ.get("RUN_LIVE_GROQ_VALIDATION") == "1",
+    "Live Groq validation is opt-in and does not run in normal tests.",
+)
+class QwenLiveValidationTests(unittest.TestCase):
+    def test_qwen_live_validation_reports_reasoning_and_sanitizes_output(self):
+        from dotenv import load_dotenv
+
+        load_dotenv(".env")
+        api_key = os.getenv("GROQ_API_KEY")
+        self.assertTrue(api_key)
+
+        summary = groq.run_groq_model(
+            groq_api_key=api_key,
+            model=QWEN_MODEL,
+            options=groq.model_options(
+                prompt=groq.summary_prompt(VALIDATION_ARTICLE_TEXT),
+                temperature=0.8,
+                max_tokens=1024,
+            ),
+            sanitize_response=False,
+        )
+        proofread = groq.run_groq_model(
+            groq_api_key=api_key,
+            model=QWEN_MODEL,
+            options=groq.model_options(
+                prompt=groq.proofreading_prompt(
+                    f"{summary}\n\nLink: {VALIDATION_ARTICLE_URL}"
+                ),
+                temperature=1,
+                max_tokens=1024,
+            ),
+            sanitize_response=False,
+        )
+
+        raw_response = f"{summary}\n{proofread}"
+        sanitized_proofread = main.ensure_link_in_proofreading_result(
+            groq.sanitize_model_response(proofread),
+            f"{summary}\n\nLink: {VALIDATION_ARTICLE_URL}",
+        )
+        sanitized_response = f"{groq.sanitize_model_response(summary)}\n{sanitized_proofread}"
+
+        print("Qwen live validation contains <think>:", "<think>" in raw_response.lower())
+        self.assertIn("Tytu", sanitized_response)
+        self.assertIn("Podsumowanie", sanitized_response)
+        self.assertIn(VALIDATION_ARTICLE_URL, sanitized_response)
+        self.assertNotIn("<think>", sanitized_response.lower())
+        self.assertNotIn("</think>", sanitized_response.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- migrate default Groq model to qwen/qwen3.6-27b
- hide Qwen reasoning output and sanitize think blocks
- add PRD 003, Milestone 1.4 docs, and unit/live validation tests

## Validation
- uv run python -m unittest discover -s tests -p "test_*.py"
- RUN_LIVE_GROQ_VALIDATION=1 uv run python -m unittest tests.test_milestone_1_4.QwenLiveValidationTests