### PR TITLE
Implement resilient article fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skrypt do podsumowywania newsow z branzy gier.
 
 ## Jak to dziala
 
-Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`. Domyslnym modelem jest `qwen/qwen3.6-27b`.
+Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), a jesli Jina zwroci blad lub niewiarygodna tresc dla `konsolowe.info`, aplikacja uzywa fallbacku przez WordPress REST API albo bezposredni HTML artykulu. Nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a kompletny wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`. Domyslnym modelem jest `qwen/qwen3.6-27b`.
 
 ## Wymagania
 
@@ -49,7 +49,7 @@ Projekt uzywa `unittest`. Standardowa komenda:
 uv run python -m unittest discover -s tests -p "test_*.py"
 ```
 
-Testy obejmuja Google Sheets, parser listingu, finalny pipeline przetwarzania linkow w trybie stubowanym oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
+Testy obejmuja Google Sheets, parser listingu, finalny pipeline przetwarzania linkow w trybie stubowanym, fallback pobierania tresci artykulu oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
 
 Opcjonalna walidacja live modelu Qwen, bez zapisu do Google Sheets i bez wysylki SMTP:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,3 +145,29 @@ Zakres:
 - przygotowanie izolowanej walidacji live na stalej probce artykulu
 - warunkowe dodanie usuwania blokow `<think>...</think>` w odpowiedziach modelu
 - dostosowanie testow jednostkowych do wyniku walidacji live
+
+---
+
+## Milestone 1.5: Odporne pobieranie treści artykułów (done)
+
+Cel:
+- zabezpieczyc pipeline przed podsumowywaniem stron bledow zwroconych przez Jina jako tresc odpowiedzi `HTTP 200`
+- dodac fallback pobierania tresci artykulow z `konsolowe.info`
+- zablokowac wysylke niekompletnych wynikow korekty
+
+Definition of Done:
+- odpowiedzi Jina zawierajace `Title: 403 Forbidden` albo `Warning: Target URL returned error 403` sa traktowane jako blad pobrania tresci
+- tresc bledu Jina nie trafia do promptu podsumowania
+- po blednej odpowiedzi Jina aplikacja probuje fallbacku przez WordPress REST API dla `konsolowe.info`
+- jesli WordPress REST API nie moze zostac uzyte, aplikacja moze sprobowac pobrac i oczyscic bezposredni HTML artykulu
+- jesli zadna sciezka nie zwroci realnej tresci artykulu, link jest pomijany bez wywolania LLM
+- niekompletny wynik korekty nie trafia do e-maila HTML ani fallbacku `plain text`
+- testy lokalne przechodza komenda `uv run python -m unittest discover -s tests -p "test_*.py"`
+
+Zakres:
+- walidacja tresci zwracanej przez Jina mimo poprawnego statusu odpowiedzi
+- fallback pobierania tresci przez WordPress REST API dla `konsolowe.info`
+- fallback pobierania i oczyszczania bezposredniego HTML artykulu
+- integracja pomijania linku z obecnym etapem podsumowania
+- walidacja kompletności wyniku korekty przed wysylka
+- testy jednostkowe bez realnego IO dla bledow Jina, fallbacku i blokady LLM

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,9 +6,10 @@
 - Model LLM jest konfigurowany przez `LLM_MODEL` w `.env`; domyslnym modelem jest `qwen/qwen3.6-27b`.
 - Stan przetworzonych linkow jest odczytywany i zapisywany w Google Sheets.
 - Listing newsow jest parsowany bezposrednio z HTML bez uzycia LLM.
-- Pelna tresc artykulow jest pobierana przez mirror Jina.
+- Pelna tresc artykulow jest pobierana przez mirror Jina z fallbackiem przez WordPress REST API lub bezposredni HTML dla `konsolowe.info`.
 - Wiadomosc e-mail jest wysylana jako multipart z fallbackiem `plain text` i stylowana warstwa HTML.
-- Testy `unittest` dla Milestone 1.0-1.4 przechodza lokalnie.
+- Niekompletne wyniki korekty LLM nie trafiaja do e-maila.
+- Testy `unittest` dla Milestone 1.0-1.5 przechodza lokalnie.
 
 ## Co jest skończone
 - Dodanie dokumentow operacyjnych repo.
@@ -18,6 +19,7 @@
 - Milestone 1.2: finalny pipeline przetwarzania linkow i obsluga bledow po append.
 - Milestone 1.3: stylowany e-mail HTML dla GameFlash z fallbackiem `plain text`.
 - Milestone 1.4: migracja domyslnego modelu Groq na `qwen/qwen3.6-27b`, walidacja live Qwen i obsluga reasoning.
+- Milestone 1.5: odporne pobieranie tresci artykulow, fallback dla `konsolowe.info` i blokada niekompletnych korekt.
 - Bazowy zestaw testow `unittest` dla Google Sheets i deduplikacji.
 - Aktualizacja bezposrednich zaleznosci do najnowszych kompatybilnych wersji.
 
@@ -31,7 +33,7 @@
 - Uruchomienie produkcyjne wymaga poprawnie uzupelnionego `.env`.
 - Walidacja live Google Sheets zalezy od dostepu konta serwisowego do wskazanego arkusza.
 - Dalsze powodzenie pipeline'u zalezy od dostepnosci Google Sheets, strony z listingiem, mirroru Jina, Groq i SMTP.
-- Model `qwen/qwen3.6-27b` wymaga ukrycia reasoning i wiekszego budzetu tokenow, aby zwracac finalna tresc zamiast technicznego procesu rozumowania.
+- Model `qwen/qwen3.6-27b` wymaga ukrycia reasoning i wiekszego budzetu tokenow, szczegolnie na etapie korekty, aby zwracac finalna tresc zamiast technicznego procesu rozumowania.
 
 ## Ostatnie aktualizacje
 - 2026-03-21: migracja konfiguracji projektu na `uv`.
@@ -41,3 +43,4 @@
 - 2026-03-22: model LLM przeniesiony do `LLM_MODEL` w `.env` i odswiezone zaleznosci wykonawcze.
 - 2026-03-22: wdrozenie Milestone 1.3, stylowany e-mail HTML, fallback `plain text` i testy lokalne warstwy maili.
 - 2026-06-27: wdrozenie Milestone 1.4, domyslny model `qwen/qwen3.6-27b`, walidacja live Qwen, ukrycie reasoning i testy lokalne.
+- 2026-06-27: wdrozenie Milestone 1.5, walidacja blednych odpowiedzi Jina, fallback WordPress/HTML, blokada niekompletnych korekt, testy lokalne i walidacja live problematycznego artykulu.

--- a/main.py
+++ b/main.py
@@ -12,6 +12,9 @@ from utils import utils
 
 DEFAULT_LLM_MODEL = "qwen/qwen3.6-27b"
 LINK_RE = re.compile(r"^Link:\s*(\S+)\s*$", re.MULTILINE)
+TITLE_RE = re.compile(r"^Tytu[łl]:\s*(.+)$", re.MULTILINE)
+SUMMARY_RE = re.compile(r"Podsumowanie:\s*(.+?)(?:\n\s*\nLink:|\nLink:|\Z)", re.DOTALL)
+SUMMARY_END_RE = re.compile(r"[.!?…][\"'”’)]*\s*$")
 
 
 def load_config():
@@ -111,6 +114,21 @@ def ensure_link_in_proofreading_result(proofreading_news: str, source_news: str)
     return f"{proofreading_news.rstrip()}\n\nLink: {link_match.group(1)}"
 
 
+def is_complete_proofreading_result(proofreading_news: str) -> bool:
+    """Sprawdza minimalna kompletnosc wyniku korekty przed wysylka."""
+    title_match = TITLE_RE.search(proofreading_news)
+    summary_match = SUMMARY_RE.search(proofreading_news)
+    link_match = LINK_RE.search(proofreading_news)
+    if not title_match or not summary_match or not link_match:
+        return False
+
+    summary = summary_match.group(1).strip()
+    if not summary:
+        return False
+
+    return bool(SUMMARY_END_RE.search(summary))
+
+
 def news_proofreading(config, news_to_corrected):
     """Przeprowadza korektę na podsumowanych newsach"""
     news_to_send = []
@@ -118,8 +136,8 @@ def news_proofreading(config, news_to_corrected):
         try:
             proofreading_model_options = groq.model_options(
                 prompt=groq.proofreading_prompt(news),
-                temperature=1,
-                max_tokens=1024,
+                temperature=0.2,
+                max_tokens=7200,
             )
             proofreading_news = groq.run_groq_model(
                 groq_api_key=config["GROQ_API"],
@@ -129,6 +147,9 @@ def news_proofreading(config, news_to_corrected):
             proofreading_news = ensure_link_in_proofreading_result(
                 proofreading_news, news
             )
+            if not is_complete_proofreading_result(proofreading_news):
+                print("Pominieto niekompletny wynik korekty newsa.")
+                continue
         except Exception as exc:
             print(f"Nie udalo sie wykonac korekty newsa: {exc}")
             continue

--- a/prd/004-article-content-fetch-resilience-prd.md
+++ b/prd/004-article-content-fetch-resilience-prd.md
@@ -1,0 +1,205 @@
+# PRD 004: Odporne pobieranie treści artykułów i blokada podsumowań z błędnych źródeł
+
+## Cel zmiany
+
+Celem tej zmiany jest zabezpieczenie GameFlash przed generowaniem podsumowań na podstawie błędnych danych wejściowych, gdy mirror Jina zwraca technicznie poprawną odpowiedź `HTTP 200`, ale treścią odpowiedzi jest komunikat błędu źródłowej strony, na przykład `403 Forbidden`.
+
+Po wdrożeniu GameFlash ma:
+- rozpoznawać odpowiedzi Jina, które nie zawierają realnej treści artykułu,
+- używać alternatywnej ścieżki pobierania treści dla artykułów z `konsolowe.info`,
+- pomijać link, jeśli nie uda się pobrać wiarygodnej treści artykułu,
+- nie wywoływać LLM dla stron błędów, pustych treści ani samych metadanych,
+- nie wysyłać e-maili z podsumowaniami opartymi na zgadywaniu modelu.
+
+## Problem do rozwiązania
+
+Obecna implementacja pobiera pełną treść artykułu przez `https://r.jina.ai/<link>`. W zaobserwowanym przypadku Jina zwróciła status `HTTP 200`, ale zawartość odpowiedzi informowała, że źródłowa strona zwróciła `403 Forbidden`.
+
+Przykładowe fragmenty błędnej odpowiedzi:
+- `Title: 403 Forbidden`,
+- `Warning: Target URL returned error 403: Forbidden`,
+- `Markdown Content: * * * nginx`.
+
+To podejście jest ryzykowne, ponieważ:
+- aplikacja traktuje taką odpowiedź jak poprawną treść artykułu,
+- LLM może wygenerować pozornie sensowne podsumowanie na podstawie tytułu i trendów rynkowych,
+- w e-mailu może znaleźć się tekst zawierający domysły, a nie streszczenie faktycznego artykułu,
+- etap korekty może dodatkowo skrócić lub zniekształcić niepoprawnie wygenerowane podsumowanie.
+
+## Zakres funkcjonalny
+
+Zmiana obejmuje:
+- walidację treści zwróconej przez Jina przed przekazaniem jej do promptu podsumowania,
+- wykrywanie odpowiedzi błędnych mimo statusu `HTTP 200`,
+- fallback pobierania treści artykułu z `konsolowe.info`,
+- blokadę wywołania LLM, jeśli nie uda się pobrać realnej treści artykułu,
+- walidację kompletności wyniku po korekcie językowej,
+- testy jednostkowe pokrywające błędne odpowiedzi Jina, fallback oraz brak wywołania LLM dla niepoprawnych danych wejściowych.
+
+Minimalnie rozpoznawane błędne odpowiedzi Jina:
+- treść zawiera `Title: 403 Forbidden`,
+- treść zawiera `Warning: Target URL returned error 403`,
+- treść jest pusta,
+- treść jest skrajnie krótka i nie zawiera realnego artykułu.
+
+## Poza zakresem
+
+Ta zmiana nie obejmuje:
+- zmiany integracji z Google Sheets,
+- zmiany modelu `qwen/qwen3.6-27b`,
+- zmiany liczby planowych wywołań LLM dla poprawnie przetworzonego newsa,
+- zmiany renderowania e-maila HTML,
+- zmiany fallbacku `plain text`,
+- zmiany logiki deduplikacji linków,
+- dodania retry workflow, kolejki zadań lub monitoringu,
+- dodania panelu użytkownika,
+- obsługi wielu źródeł newsów innych niż obecny przepływ dla `konsolowe.info`.
+
+## Docelowy przepływ
+
+Docelowy przebieg pobierania i przetwarzania treści artykułu:
+
+1. Aplikacja wykrywa nowy link i zapisuje go do Google Sheets zgodnie z obecnym przepływem.
+2. Aplikacja próbuje pobrać treść artykułu przez Jina.
+3. Aplikacja waliduje treść zwróconą przez Jina.
+4. Jeśli treść z Jina jest poprawna, zostaje przekazana do etapu podsumowania.
+5. Jeśli treść z Jina wygląda jak błąd źródła, aplikacja uruchamia fallback dla `konsolowe.info`.
+6. Preferowany fallback pobiera treść przez WordPress REST API `wp-json/wp/v2/posts/<id>`, jeśli ID posta da się ustalić z HTML lub nagłówka `Link`.
+7. Alternatywny fallback pobiera bezpośrednio HTML artykułu i oczyszcza główną treść.
+8. Jeśli fallback zwróci realną treść artykułu, dopiero wtedy aplikacja wywołuje LLM.
+9. Jeśli Jina i fallback nie dostarczą realnej treści, aplikacja pomija dany link w bieżącym przebiegu.
+10. Wynik korekty jest walidowany przed dodaniem do listy newsów do wysyłki.
+11. Niekompletny wynik korekty nie trafia do e-maila.
+
+## Wymagania techniczne
+
+### 1. Walidacja odpowiedzi Jina
+
+Decyzja:
+- odpowiedź Jina musi zostać sprawdzona pod kątem treści błędu przed użyciem jej jako wejścia dla LLM.
+
+Uzasadnienie:
+- status `HTTP 200` z Jina nie gwarantuje, że pobranie źródłowego artykułu się udało.
+
+Konsekwencje:
+- moduł pobierania treści musi odróżniać realny artykuł od komunikatu błędu,
+- wykryty błąd powinien uruchomić fallback zamiast generowania podsumowania.
+
+### 2. Fallback przez WordPress REST API
+
+Decyzja:
+- dla linków z `konsolowe.info` preferowanym fallbackiem jest publiczne WordPress REST API.
+
+Uzasadnienie:
+- artykuły z `konsolowe.info` są publikowane w WordPressie,
+- endpoint `wp-json/wp/v2/posts/<id>` może zwrócić pełną treść posta nawet wtedy, gdy Jina dostaje `403 Forbidden`.
+
+Konsekwencje:
+- implementacja musi umieć ustalić ID posta, jeśli jest dostępne w HTML lub nagłówku `Link`,
+- treść HTML z pola `content.rendered` musi zostać oczyszczona z tagów i elementów technicznych przed przekazaniem do LLM.
+
+### 3. Fallback przez bezpośredni HTML
+
+Decyzja:
+- jeśli WordPress REST API nie może zostać użyte, aplikacja może spróbować pobrać artykuł bezpośrednio i oczyścić treść HTML.
+
+Uzasadnienie:
+- bezpośrednie pobranie strony może działać poprawnie, nawet jeśli Jina jest blokowana przez źródło.
+
+Konsekwencje:
+- parser HTML powinien wyciągać właściwą treść artykułu, a nie menu, stopkę, reklamy, komentarze ani listę powiązanych wpisów,
+- jeśli nie da się jednoznacznie uzyskać treści artykułu, link powinien zostać pominięty.
+
+### 4. Blokada LLM dla niepoprawnej treści
+
+Decyzja:
+- LLM nie może być wywołany, jeśli wejściem miałaby być strona błędu, pusta treść, sam tytuł lub same metadane SEO.
+
+Uzasadnienie:
+- model może wygenerować wiarygodnie brzmiące, ale niezweryfikowane podsumowanie.
+
+Konsekwencje:
+- etap `summarize_news` powinien pomijać link, dla którego nie udało się pobrać realnej treści,
+- w logach powinien pojawić się czytelny komunikat o pominięciu linku.
+
+### 5. Walidacja kompletności korekty
+
+Decyzja:
+- wynik po korekcie językowej musi zostać zweryfikowany przed wysyłką.
+
+Minimalne wymagania dla poprawnego wyniku:
+- zawiera `Tytuł:`,
+- zawiera `Podsumowanie:`,
+- zawiera `Link:`,
+- podsumowanie nie jest puste,
+- tekst nie wygląda na ucięty w połowie zdania.
+
+Uzasadnienie:
+- model może zakończyć odpowiedź przedwcześnie albo pominąć część wymaganego formatu.
+
+Konsekwencje:
+- niekompletny wynik korekty nie powinien trafić do maila HTML ani fallbacku `plain text`,
+- link może nadal być zachowywany przez istniejący mechanizm dopisywania `Link:`, ale samo zachowanie linku nie wystarcza do uznania wyniku za poprawny.
+
+## Scenariusze akceptacyjne
+
+1. Jina zwraca błąd `403` jako treść odpowiedzi
+- jeśli Jina zwraca `HTTP 200`, ale treść zawiera `Title: 403 Forbidden`, wynik jest traktowany jako błąd pobrania artykułu.
+
+2. Jina zwraca ostrzeżenie o błędzie źródła
+- jeśli treść zawiera `Warning: Target URL returned error 403`, aplikacja nie przekazuje tej treści do LLM.
+
+3. Fallback WordPress REST API
+- jeśli Jina zwraca błędną treść, a WordPress REST API zwraca pełną treść posta, aplikacja używa oczyszczonej treści z API do podsumowania.
+
+4. Fallback bezpośredniego HTML
+- jeśli WordPress REST API nie jest dostępne, aplikacja może użyć bezpośredniego HTML artykułu, o ile parser potrafi uzyskać realną treść.
+
+5. Brak realnej treści
+- jeśli Jina i fallback nie dostarczą realnej treści, link jest pomijany w bieżącym przebiegu.
+
+6. Brak wywołania LLM dla błędu
+- strona błędu `403 Forbidden` nie trafia do promptu podsumowania.
+
+7. Brak zgadywania z tytułu
+- jeśli dostępny jest tylko tytuł lub metadane SEO bez treści artykułu, aplikacja nie generuje podsumowania.
+
+8. Niekompletna korekta
+- jeśli wynik korekty jest ucięty lub nie zawiera wymaganych pól, nie trafia do e-maila.
+
+9. Brak regresji poprawnego przepływu
+- jeśli Jina zwraca realną treść artykułu, aplikacja zachowuje dotychczasowy przepływ: podsumowanie, korekta, wysyłka multipart.
+
+## Testy i scenariusze walidacyjne
+
+Implementacja wynikająca z tego PRD ma zostać pokryta testami `unittest` bez realnego IO.
+
+Testy powinny weryfikować co najmniej:
+- Jina zwraca `HTTP 200` z treścią `403 Forbidden` i wynik jest uznany za błąd źródła,
+- Jina zwraca ostrzeżenie `Warning: Target URL returned error 403` i treść nie trafia do LLM,
+- po błędzie Jina uruchamia się fallback WordPress REST API,
+- fallback WordPress REST API zwraca oczyszczoną treść artykułu,
+- gdy Jina i fallback zawodzą, link jest pomijany bez wywołania LLM,
+- treść błędu `403` nigdy nie trafia do promptu podsumowania,
+- pusta lub skrajnie krótka treść jest odrzucana,
+- niekompletna odpowiedź korekty nie trafia do maila,
+- poprawny artykuł nadal przechodzi przez istniejący przepływ podsumowania i korekty,
+- testy nie wykonują realnego SMTP,
+- testy nie zapisują danych do Google Sheets,
+- testy nie zależą od dostępności `konsolowe.info`, Jina ani Groq.
+
+Standardowa komenda testów pozostaje:
+
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"
+```
+
+## Założenia
+
+- Jina pozostaje pierwszą próbą pobrania treści artykułu.
+- Jina nie jest traktowana jako w pełni zaufane źródło, ponieważ może zwrócić stronę błędu jako treść odpowiedzi `HTTP 200`.
+- Dla `konsolowe.info` WordPress REST API jest akceptowalnym fallbackiem, jeśli publicznie zwraca treść posta.
+- Jeśli nie da się pobrać realnego artykułu, lepiej pominąć newsa niż wysłać halucynowane podsumowanie.
+- Link zapisany wcześniej w Google Sheets nie jest automatycznie usuwany w ramach tej zmiany.
+- Obecna architektura skryptowa pozostaje właściwa i nie wymaga przebudowy.
+- PRD opisuje przyszłą poprawkę implementacyjną, ale samo dodanie dokumentu nie zmienia działania aplikacji.

--- a/scrapers/jina.py
+++ b/scrapers/jina.py
@@ -1,11 +1,127 @@
 """Pobieranie tresci artykulow przez mirror Jina."""
 
+import html
+import re
+from urllib.parse import urlparse
+
+from bs4 import BeautifulSoup
 import requests
+
+JINA_AI_URL = "https://r.jina.ai/"
+MIN_ARTICLE_TEXT_LENGTH = 200
+JINA_ERROR_PATTERNS = (
+    "Title: 403 Forbidden",
+    "Warning: Target URL returned error 403",
+)
+WP_POST_RE = re.compile(r"/wp-json/wp/v2/posts/(\d+)")
+
+
+class ArticleContentError(RuntimeError):
+    """Sygnalizuje brak wiarygodnej tresci artykulu."""
+
+
+def _normalize_text(value: str) -> str:
+    """Porzadkuje biale znaki w tekscie artykulu."""
+    return re.sub(r"\s+", " ", html.unescape(value or "")).strip()
+
+
+def validate_article_text(text: str) -> str:
+    """Zwraca tekst artykulu albo zglasza blad dla odpowiedzi technicznych."""
+    normalized_text = _normalize_text(text)
+    for error_pattern in JINA_ERROR_PATTERNS:
+        if error_pattern in normalized_text:
+            raise ArticleContentError("Jina zwrocila blad zrodla zamiast tresci.")
+
+    if len(normalized_text) < MIN_ARTICLE_TEXT_LENGTH:
+        raise ArticleContentError("Pobrana tresc artykulu jest zbyt krotka.")
+
+    return normalized_text
+
+
+def _is_konsolowe_url(url: str) -> bool:
+    """Sprawdza, czy link prowadzi do obslugiwanego zrodla WordPress."""
+    hostname = urlparse(url).hostname or ""
+    return hostname == "konsolowe.info" or hostname.endswith(".konsolowe.info")
+
+
+def _extract_post_id(response: requests.Response) -> str | None:
+    """Wyciaga ID posta WordPress z naglowka Link albo HTML."""
+    header_link = response.headers.get("Link", "")
+    header_match = WP_POST_RE.search(header_link)
+    if header_match:
+        return header_match.group(1)
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    wp_link = soup.find("link", attrs={"rel": "alternate", "type": "application/json"})
+    if wp_link:
+        href = str(wp_link.get("href", ""))
+        href_match = WP_POST_RE.search(href)
+        if href_match:
+            return href_match.group(1)
+
+    return None
+
+
+def _clean_html_text(html_content: str) -> str:
+    """Oczyszcza HTML artykulu do tekstu dla LLM."""
+    soup = BeautifulSoup(html_content, "html.parser")
+    for element in soup(["script", "style", "noscript", "iframe"]):
+        element.decompose()
+    return _normalize_text(soup.get_text(" "))
+
+
+def _article_text_from_direct_html(html_content: str) -> str:
+    """Wyciaga glowna tresc artykulu z bezposredniego HTML."""
+    soup = BeautifulSoup(html_content, "html.parser")
+    for element in soup(["script", "style", "noscript", "iframe"]):
+        element.decompose()
+
+    article_node = soup.select_one(
+        "article .entry-content, article #entry, article, #entry, .entry-content, main"
+    )
+    if article_node is None:
+        article_node = soup.body or soup
+
+    return _normalize_text(article_node.get_text(" "))
+
+
+def _fetch_from_wordpress_api(url: str, post_id: str) -> str:
+    """Pobiera tresc posta przez WordPress REST API."""
+    parsed_url = urlparse(url)
+    api_url = f"{parsed_url.scheme}://{parsed_url.netloc}/wp-json/wp/v2/posts/{post_id}"
+    response = requests.get(api_url, timeout=30)
+    response.raise_for_status()
+    post_data = response.json()
+    rendered_content = post_data.get("content", {}).get("rendered", "")
+    return validate_article_text(_clean_html_text(rendered_content))
+
+
+def _fetch_article_fallback(url: str) -> str:
+    """Pobiera tresc artykulu z fallbackow dla konsolowe.info."""
+    if not _is_konsolowe_url(url):
+        raise ArticleContentError("Brak fallbacku dla tego zrodla.")
+
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+
+    post_id = _extract_post_id(response)
+    if post_id:
+        try:
+            return _fetch_from_wordpress_api(url, post_id)
+        except Exception as exc:
+            print(f"Nie udalo sie pobrac tresci przez WordPress REST API: {url} ({exc})")
+
+    return validate_article_text(_article_text_from_direct_html(response.text))
 
 
 def fetch_article_text(url: str) -> str:
-    """Pobiera tresc artykulu przez mirror Jina."""
-    jina_ai = "https://r.jina.ai/"
-    response = requests.get(f"{jina_ai}{url}", timeout=30)
-    response.raise_for_status()
-    return response.text
+    """Pobiera tresc artykulu przez Jina z fallbackiem dla zrodel WordPress."""
+    try:
+        response = requests.get(f"{JINA_AI_URL}{url}", timeout=30)
+        response.raise_for_status()
+        return validate_article_text(response.text)
+    except ArticleContentError:
+        return _fetch_article_fallback(url)
+    except requests.RequestException as exc:
+        print(f"Nie udalo sie pobrac tresci przez Jina: {url} ({exc})")
+        return _fetch_article_fallback(url)

--- a/spec.md
+++ b/spec.md
@@ -40,6 +40,14 @@ Planowane rozszerzenie zakresu wynikające z PRD `003-qwen-model-migration-prd.m
 
 Rozszerzenie z PRD `003-qwen-model-migration-prd.md` zostalo wdrozone.
 
+Planowane rozszerzenie zakresu wynikające z PRD `004-article-content-fetch-resilience-prd.md`:
+- wykrywanie błędnych odpowiedzi Jina mimo statusu `HTTP 200`,
+- dodanie fallbacku pobierania treści artykułów z `konsolowe.info`,
+- blokowanie wywołań LLM dla stron błędów, pustych treści i samych metadanych,
+- walidacja kompletności wyniku korekty przed wysyłką e-maila.
+
+Rozszerzenie z PRD `004-article-content-fetch-resilience-prd.md` zostalo wdrozone.
+
 ---
 
 ## Zakres funkcjonalny (high-level)
@@ -59,9 +67,10 @@ Główny przepływ:
 5. Wyciąga linki z HTML na podstawie wzorca bieżącego roku i miesiąca.
 6. Usuwa duplikaty z bieżącego przebiegu i odrzuca linki obecne już w Google Sheets.
 7. Dla każdego nowego linku wykonuje append do Google Sheets.
-8. Dla poprawnie dopisanych linków pobiera treść artykułów przez `https://r.jina.ai/<link>`.
+8. Dla poprawnie dopisanych linków pobiera treść artykułów przez `https://r.jina.ai/<link>` albo fallback dla `konsolowe.info`, jeśli Jina zwróci błąd lub niewiarygodną treść.
 9. Generuje podsumowania i wykonuje ich korektę językową.
-10. Wysyła pojedynczy e-mail ze wszystkimi nowymi podsumowaniami.
+10. Odrzuca niekompletne wyniki korekty.
+11. Wysyła pojedynczy e-mail ze wszystkimi poprawnie przygotowanymi podsumowaniami.
 
 Docelowy przepływ wynikający z PRD `001-google-sheets-link-store-prd.md`:
 1. Aplikacja ładuje konfigurację z `.env`.
@@ -95,6 +104,15 @@ Docelowy przeplyw wynikajacy z PRD `003-qwen-model-migration-prd.md`:
 6. Normalny pipeline nadal wykonuje dwa wywolania modelu na poprawnie przetworzony news: podsumowanie i korekte.
 7. Aplikacja nadal wysyla jeden e-mail multipart z gotowymi podsumowaniami.
 
+Docelowy przeplyw wynikajacy z PRD `004-article-content-fetch-resilience-prd.md`:
+1. Aplikacja probuje pobrac tresc artykulu przez Jina.
+2. Aplikacja waliduje, czy odpowiedz Jina zawiera realna tresc artykulu, a nie komunikat bledu zrodla.
+3. Jesli Jina zwraca bledna tresc mimo statusu `HTTP 200`, aplikacja uruchamia fallback dla `konsolowe.info`.
+4. Preferowany fallback pobiera tresc przez WordPress REST API, jesli da sie ustalic ID posta.
+5. Alternatywny fallback pobiera bezposredni HTML artykulu i oczyszcza glowna tresc.
+6. Jesli zadna sciezka nie dostarczy realnej tresci, aplikacja pomija link i nie wywoluje LLM.
+7. Wynik korekty jezykowej jest sprawdzany pod katem kompletnosci przed dodaniem do maila.
+
 Czego aplikacja obecnie nie robi:
 - nie waliduje kompleksowo konfiguracji przed startem,
 - nie obsługuje wielu źródeł wejściowych ani wielu modeli,
@@ -109,7 +127,7 @@ Architektura ma postać prostego skryptu orkiestrującego z kilkoma modułami po
 1. Główne komponenty systemu
 - `main.py` odpowiada za sekwencję wykonania całego procesu.
 - `scrapers/listing.py` pobiera i parsuje HTML listingu newsów.
-- `scrapers/jina.py` pobiera treść pojedynczego artykułu przez mirror Jina.
+- `scrapers/jina.py` pobiera treść pojedynczego artykułu przez mirror Jina i fallback dla `konsolowe.info`.
 - `llms/groq.py` buduje prompty i wykonuje wywołania modelu Groq.
 - `storage/google_sheets.py` obsługuje odczyt i zapis stanu linków w Google Sheets.
 - `emails/gmail.py` składa i wysyła wiadomość SMTP.
@@ -126,6 +144,12 @@ Planowane rozszerzenie komponentow wynikajace z PRD `003-qwen-model-migration-pr
 - konfiguracja modelu ma wskazywac domyslnie `qwen/qwen3.6-27b`,
 - ewentualna warstwa usuwania blokow `<think>...</think>` ma zostac dodana tylko wtedy, gdy test live wykaze taka potrzebe.
 
+Planowane rozszerzenie komponentow wynikajace z PRD `004-article-content-fetch-resilience-prd.md`:
+- `scrapers/jina.py` ma walidowac, czy odpowiedz z Jina zawiera realna tresc artykulu,
+- warstwa pobierania tresci ma dostac fallback dla `konsolowe.info` oparty o WordPress REST API lub bezposredni HTML,
+- `main.py` ma pomijac linki, dla ktorych nie udalo sie pobrac wiarygodnej tresci,
+- etap korekty ma weryfikowac kompletnosc wyniku przed przekazaniem newsa do warstwy mailowej.
+
 2. Przepływ danych między komponentami
 - Wejście konfiguracyjne pochodzi z `.env` i stałych zaszytych w `main.py`.
 - Konfiguracja obejmuje także `GOOGLE_SHEET_ID`, `GOOGLE_SHEET_WORKSHEET` i `GSPREAD_SERVICE_ACCOUNT_FILE`.
@@ -133,9 +157,9 @@ Planowane rozszerzenie komponentow wynikajace z PRD `003-qwen-model-migration-pr
 - Listing newsów jest pobierany jako HTML bezpośrednio z URL źródłowego.
 - Parser HTML wyodrębnia linki zgodne ze wzorcem `https://konsolowe.info/<YYYY>/<MM>/`.
 - Każdy nowy link jest najpierw zapisywany w Google Sheets.
-- Dla poprawnie zapisanych linków pobierana jest pełna treść artykułów przez mirror Jina.
+- Dla poprawnie zapisanych linków pobierana jest pełna treść artykułów przez mirror Jina, a przy błędnej odpowiedzi przez fallback `konsolowe.info`.
 - Model Groq generuje podsumowanie, a następnie osobny prompt wykonuje korektę tekstu.
-- Gotowe sekcje podsumowań są łączone w jeden e-mail wysyłany przez SMTP.
+- Kompletne sekcje podsumowań są łączone w jeden e-mail wysyłany przez SMTP.
 
 Docelowy przepływ danych wynikający z PRD `001-google-sheets-link-store-prd.md`:
 - Wejście konfiguracyjne ma obejmować także `GOOGLE_SHEET_ID`, `GOOGLE_SHEET_WORKSHEET` i `GSPREAD_SERVICE_ACCOUNT_FILE`.
@@ -158,6 +182,13 @@ Docelowy przeplyw danych wynikajacy z PRD `003-qwen-model-migration-prd.md`:
 - walidacja live wykazala, ze surowa odpowiedz Qwen moze zawierac bloki `<think>...</think>`, dlatego odpowiedzi modelu sa zabezpieczone przed przekazaniem reasoning do korekty i warstwy maili,
 - wywolania Qwen uzywaja ukrytego reasoning oraz lokalnej sanitizacji jako zabezpieczenia.
 
+Docelowy przeplyw danych wynikajacy z PRD `004-article-content-fetch-resilience-prd.md`:
+- tresc z Jina nie jest automatycznie traktowana jako wiarygodna tylko dlatego, ze odpowiedz miala status `HTTP 200`,
+- komunikaty bledu takie jak `Title: 403 Forbidden` i `Warning: Target URL returned error 403` nie moga trafic do promptu podsumowania,
+- dla artykulow z `konsolowe.info` alternatywna sciezka moze pobrac tresc przez WordPress REST API albo bezposredni HTML,
+- brak realnej tresci artykulu konczy przetwarzanie danego linku przed etapem LLM,
+- niekompletny wynik korekty nie trafia do reprezentacji `plain text` ani `html`.
+
 3. Granice odpowiedzialności
 - Logika przepływu pozostaje w `main.py`.
 - Integracje z zewnętrznymi usługami są rozdzielone na moduły `scrapers`, `llms` i `emails`.
@@ -177,6 +208,11 @@ Po wdrozeniu PRD `003-qwen-model-migration-prd.md`:
 - warstwa LLM pozostanie odpowiedzialna wylacznie za podsumowanie i korekte tekstu,
 - liczba wywolan modelu w normalnym pipeline pozostanie bez zmian,
 - test live nowego modelu pozostanie czynnoscia walidacyjna, a nie etapem przetwarzania kazdego artykulu.
+
+Po wdrozeniu PRD `004-article-content-fetch-resilience-prd.md`:
+- warstwa pobierania tresci odrzuca strony bledow i uruchamia fallback,
+- warstwa LLM nadal odpowiada wylacznie za podsumowanie i korekte realnej tresci artykulu,
+- warstwa maili nie przyjmuje niekompletnych wynikow korekty.
 
 ---
 
@@ -213,6 +249,21 @@ Rozszerzenia techniczne po wdrozeniu PRD `003-qwen-model-migration-prd.md`:
 - odpowiedzi modelu sa dodatkowo czyszczone z kompletnych blokow `<think>...</think>` jako zabezpieczenie,
 - dla modelu `qwen/qwen3.6-27b` minimalny budzet `max_tokens` zostal podniesiony, aby reasoning nie zuzywal calego limitu przed finalna odpowiedzia,
 - wynik korekty jest zabezpieczony przed utrata linku: jesli model pominie `Link:`, aplikacja dopisuje link z wejscia.
+
+Planowane rozszerzenia techniczne wynikajace z PRD `004-article-content-fetch-resilience-prd.md`:
+- wykrywanie blednych odpowiedzi Jina po tresci odpowiedzi, niezaleznie od statusu HTTP zwroconego przez Jina,
+- fallback pobierania tresci przez WordPress REST API dla `konsolowe.info`,
+- fallback pobierania i oczyszczania bezposredniego HTML artykulu, jesli WordPress REST API nie moze zostac uzyte,
+- walidacja minimalnej kompletności wyniku korekty przed wysylka,
+- brak nowych zaleznosci wykonawczych, o ile oczyszczanie HTML da sie zrealizowac obecnym stosem `requests` i `BeautifulSoup`.
+
+Rozszerzenia techniczne po wdrozeniu PRD `004-article-content-fetch-resilience-prd.md`:
+- odpowiedzi Jina zawierajace `Title: 403 Forbidden` albo `Warning: Target URL returned error 403` sa odrzucane przed etapem LLM,
+- bledy HTTP lub sieciowe Jina uruchamiaja fallback dla `konsolowe.info`,
+- fallback probuje pobrac tresc przez WordPress REST API, a potem przez bezposredni HTML artykulu,
+- wynik korekty musi zawierac tytul, podsumowanie, link i domkniete zdanie,
+- korekta Qwen uzywa nizszej temperatury i wyzszego budzetu tokenow, aby ograniczyc ryzyko pustych lub ucietych odpowiedzi,
+- nie dodano nowych zaleznosci wykonawczych.
 
 ---
 
@@ -312,6 +363,26 @@ Każda decyzja powinna zawierać:
 - Uzasadnienie: migracja modelu zostala wdrozona bez zmiany liczby wywolan modelu, zrodla danych, deduplikacji i wysylki maili.
 - Konsekwencje: kolejne zmiany moga rozwijac jakosc promptow lub walidacje konfiguracji bez rewizji decyzji o modelu domyslnym.
 
+- Decyzja (dotyczy PRD: `004-article-content-fetch-resilience-prd.md`): odpowiedz Jina ma byc walidowana po tresci przed przekazaniem jej do LLM.
+- Uzasadnienie: Jina moze zwrocic status `HTTP 200`, mimo ze trescia odpowiedzi jest blad zrodla, na przyklad `403 Forbidden`.
+- Konsekwencje: strony bledow, puste tresci i skrajnie krotkie odpowiedzi nie beda traktowane jako artykul do podsumowania.
+
+- Decyzja (dotyczy PRD: `004-article-content-fetch-resilience-prd.md`): dla `konsolowe.info` fallbackiem pobierania tresci ma byc WordPress REST API, a nastepnie bezposredni HTML artykulu.
+- Uzasadnienie: artykuly zrodla sa publikowane w WordPressie, a publiczny endpoint moze zwrocic pelna tresc nawet wtedy, gdy Jina jest blokowana.
+- Konsekwencje: warstwa pobierania tresci bedzie miec wiecej niz jedna sciezke dla artykulu, ale bez dodawania nowego zrodla newsow.
+
+- Decyzja (dotyczy PRD: `004-article-content-fetch-resilience-prd.md`): jesli nie udalo sie pobrac realnej tresci artykulu, link ma zostac pominiety bez wywolania LLM.
+- Uzasadnienie: brak tresci artykulu jest bezpieczniejszy niz wygenerowanie halucynowanego podsumowania na podstawie tytulu, bledu lub metadanych.
+- Konsekwencje: link dopisany juz do Google Sheets nie bedzie automatycznie usuwany, a dany news moze nie zostac wyslany w biezacym przebiegu.
+
+- Decyzja (dotyczy PRD: `004-article-content-fetch-resilience-prd.md`): wynik korekty jezykowej musi zostac sprawdzony pod katem minimalnej kompletności przed wysylka.
+- Uzasadnienie: model moze zwrocic tekst uciety albo pominac wymagane pola, nawet jesli link zostanie dopisany przez zabezpieczenie.
+- Konsekwencje: niekompletny wynik korekty nie trafi do e-maila HTML ani fallbacku `plain text`.
+
+- Konflikt specyfikacji (dotyczy PRD: `004-article-content-fetch-resilience-prd.md`): PRD doprecyzowuje historyczna decyzje o pobieraniu pelnej tresci artykulow przez Jina.
+- Uzasadnienie: Milestone 1.2 zakladal Jina jako sciezke pobierania tresci, ale zaobserwowano przypadek, w ktorym Jina zwrocila blad zrodla jako tresc odpowiedzi `HTTP 200`.
+- Konsekwencje: Jina pozostaje pierwsza proba pobrania tresci, ale nie bedzie jedynym ani bezwarunkowo zaufanym zrodlem tresci artykulu.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -357,6 +428,15 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `003-qwen-model-migration-p
 - jesli walidacja live nie wykaze blokow `<think>...</think>`, pipeline nie otrzymuje dodatkowej sanitizacji,
 - normalny pipeline nadal wykonuje dwa wywolania modelu na poprawnie przetworzony news.
 
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `004-article-content-fetch-resilience-prd.md`:
+- odpowiedz Jina zawierajaca `Title: 403 Forbidden` albo `Warning: Target URL returned error 403` jest traktowana jako blad pobrania tresci,
+- tresc bledu Jina nie trafia do promptu podsumowania,
+- po blednej odpowiedzi Jina aplikacja probuje pobrac tresc przez fallback dla `konsolowe.info`,
+- jesli fallback zwroci realna tresc artykulu, aplikacja kontynuuje podsumowanie i korekte,
+- jesli nie uda sie pobrac realnej tresci artykulu, aplikacja pomija link bez wywolania LLM,
+- niekompletny wynik korekty nie jest wysylany w mailu HTML ani `plain text`,
+- testy jednostkowe pokrywaja bledna odpowiedz Jina, fallback i brak realnego IO.
+
 ---
 
 ## Zasady zmian i ewolucji
@@ -374,11 +454,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `003-qwen-model-migration-p
 - Realizacja tego PRD wymaga nowych milestone'ów po Milestone 0.5, obejmujących integrację z Google Sheets, migrację przepływu i domknięcie jakości operacyjnej.
 - PRD `002-gaming-email-styles-prd.md` wprowadza kolejny przyrost funkcjonalny: przejscie z maila `plain text` na stylowana wiadomosc HTML z fallbackiem `plain text`.
 - PRD `003-qwen-model-migration-prd.md` wprowadza kolejny przyrost funkcjonalny: migracje domyslnego modelu Groq na `qwen/qwen3.6-27b` wraz z walidacja live ryzyka reasoning.
-- Milestone 1.0, 1.1, 1.2, 1.3 i 1.4 sa wdrozone.
+- PRD `004-article-content-fetch-resilience-prd.md` wprowadza kolejny przyrost funkcjonalny: odporne pobieranie tresci artykulow, fallback dla `konsolowe.info` i blokade podsumowan z blednych zrodel.
+- Milestone 1.0, 1.1, 1.2, 1.3, 1.4 i 1.5 sa wdrozone.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
 - Ostatnia aktualizacja: 2026-06-27
-- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.4 i domknieciu PRD `003-qwen-model-migration-prd.md`
+- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.5 i domknieciu PRD `004-article-content-fetch-resilience-prd.md`

--- a/tests/test_milestone_1_5.py
+++ b/tests/test_milestone_1_5.py
@@ -1,0 +1,254 @@
+import unittest
+
+import main
+from scrapers import jina
+
+
+ARTICLE_URL = "https://konsolowe.info/2026/06/test-artykul/"
+JINA_URL = f"https://r.jina.ai/{ARTICLE_URL}"
+WP_API_URL = "https://konsolowe.info/wp-json/wp/v2/posts/123"
+
+
+class FakeResponse:
+    def __init__(self, text="", status_code=200, headers=None, json_data=None):
+        self.text = text
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._json_data = json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise jina.requests.HTTPError(f"HTTP {self.status_code}")
+
+    def json(self):
+        if self._json_data is None:
+            raise RuntimeError("no json")
+        return self._json_data
+
+
+class MilestoneOneFiveJinaTests(unittest.TestCase):
+    def setUp(self):
+        self.original_get = jina.requests.get
+
+    def tearDown(self):
+        jina.requests.get = self.original_get
+
+    def test_validate_article_text_rejects_jina_403_body(self):
+        with self.assertRaisesRegex(jina.ArticleContentError, "blad zrodla"):
+            jina.validate_article_text(
+                "Title: 403 Forbidden\n\n"
+                f"URL Source: {ARTICLE_URL}\n\n"
+                "Warning: Target URL returned error 403: Forbidden"
+            )
+
+    def test_jina_403_body_uses_wordpress_api_fallback(self):
+        calls = []
+        article_html = (
+            "<html><head>"
+            '<link rel="alternate" type="application/json" '
+            'href="https://konsolowe.info/wp-json/wp/v2/posts/123">'
+            "</head><body></body></html>"
+        )
+        article_text = (
+            "To jest pelna tresc artykulu z WordPress REST API. "
+            "Zawiera informacje o premierze gry, reakcjach graczy, wydaniu "
+            "pudelkowym oraz szerszym kontekscie rynku. "
+        ) * 4
+
+        def fake_get(url, timeout=30):
+            calls.append((url, timeout))
+            if url == JINA_URL:
+                return FakeResponse(
+                    "Title: 403 Forbidden\nWarning: Target URL returned error 403"
+                )
+            if url == ARTICLE_URL:
+                return FakeResponse(article_html)
+            if url == WP_API_URL:
+                return FakeResponse(
+                    json_data={"content": {"rendered": f"<p>{article_text}</p>"}}
+                )
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        jina.requests.get = fake_get
+
+        result = jina.fetch_article_text(ARTICLE_URL)
+
+        self.assertIn("pelna tresc artykulu", result)
+        self.assertNotIn("403 Forbidden", result)
+        self.assertEqual(
+            [(JINA_URL, 30), (ARTICLE_URL, 30), (WP_API_URL, 30)],
+            calls,
+        )
+
+    def test_jina_http_error_uses_wordpress_api_fallback(self):
+        calls = []
+        article_html = (
+            "<html><head>"
+            '<link rel="alternate" type="application/json" '
+            'href="https://konsolowe.info/wp-json/wp/v2/posts/123">'
+            "</head><body></body></html>"
+        )
+        article_text = (
+            "To jest pelna tresc artykulu pobrana po bledzie HTTP Jina. "
+            "Zawiera opis wydarzen, kontekst rynkowy i informacje wystarczajace "
+            "do przygotowania rzetelnego podsumowania. "
+        ) * 4
+
+        def fake_get(url, timeout=30):
+            calls.append((url, timeout))
+            if url == JINA_URL:
+                return FakeResponse(status_code=503)
+            if url == ARTICLE_URL:
+                return FakeResponse(article_html)
+            if url == WP_API_URL:
+                return FakeResponse(
+                    json_data={"content": {"rendered": f"<p>{article_text}</p>"}}
+                )
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        jina.requests.get = fake_get
+
+        result = jina.fetch_article_text(ARTICLE_URL)
+
+        self.assertIn("pobrana po bledzie HTTP Jina", result)
+        self.assertEqual(
+            [(JINA_URL, 30), (ARTICLE_URL, 30), (WP_API_URL, 30)],
+            calls,
+        )
+
+    def test_jina_403_body_uses_direct_html_when_wordpress_api_fails(self):
+        article_text = (
+            "Bezposredni HTML zawiera realna tresc artykulu o grze, "
+            "wydaniu pudelkowym, reakcji studia i konsekwencjach dla rynku. "
+        ) * 4
+
+        def fake_get(url, timeout=30):
+            if url == JINA_URL:
+                return FakeResponse(
+                    "Title: 403 Forbidden\nWarning: Target URL returned error 403"
+                )
+            if url == ARTICLE_URL:
+                return FakeResponse(
+                    "<html><body><article><div id='entry'>"
+                    f"<p>{article_text}</p>"
+                    "</div></article></body></html>",
+                    headers={"Link": '<https://konsolowe.info/wp-json/wp/v2/posts/123>; rel="alternate"'},
+                )
+            if url == WP_API_URL:
+                return FakeResponse(status_code=500)
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        jina.requests.get = fake_get
+
+        result = jina.fetch_article_text(ARTICLE_URL)
+
+        self.assertIn("Bezposredni HTML zawiera realna tresc", result)
+        self.assertNotIn("403 Forbidden", result)
+
+    def test_fetch_article_text_raises_when_all_sources_fail(self):
+        def fake_get(url, timeout=30):
+            if url == JINA_URL:
+                return FakeResponse(
+                    "Title: 403 Forbidden\nWarning: Target URL returned error 403"
+                )
+            if url == ARTICLE_URL:
+                return FakeResponse("<html><body><article>Za krotko.</article></body></html>")
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        jina.requests.get = fake_get
+
+        with self.assertRaises(jina.ArticleContentError):
+            jina.fetch_article_text(ARTICLE_URL)
+
+
+class MilestoneOneFivePipelineTests(unittest.TestCase):
+    def setUp(self):
+        self.original_fetch_article = main.jina.fetch_article_text
+        self.original_run_model = main.groq.run_groq_model
+
+    def tearDown(self):
+        main.jina.fetch_article_text = self.original_fetch_article
+        main.groq.run_groq_model = self.original_run_model
+
+    def test_fetch_error_prevents_403_body_from_reaching_summary_prompt(self):
+        prompts = []
+        main.jina.fetch_article_text = lambda url: (_ for _ in ()).throw(
+            RuntimeError("Jina zwrocila blad zrodla zamiast tresci.")
+        )
+
+        def fake_run_model(groq_api_key, model, options):
+            prompts.append(options["prompt"])
+            return "unused"
+
+        main.groq.run_groq_model = fake_run_model
+
+        result = main.summarize_news(
+            {"GROQ_API": "test", "LLM_MODEL": "model"},
+            [ARTICLE_URL],
+        )
+
+        self.assertEqual([], result)
+        self.assertEqual([], prompts)
+
+    def test_incomplete_proofreading_result_is_not_sent(self):
+        main.groq.run_groq_model = lambda groq_api_key, model, options: (
+            "Tytuł: News\n\n"
+            "Podsumowanie: Tekst jest uciety w polowie zdania\n\n"
+            f"Link: {ARTICLE_URL}"
+        )
+
+        result = main.news_proofreading(
+            {"GROQ_API": "test", "LLM_MODEL": "model"},
+            [
+                "Tytuł: News\n\n"
+                "Podsumowanie: Szkic.\n\n"
+                f"Link: {ARTICLE_URL}\n\n"
+                "################################"
+            ],
+        )
+
+        self.assertEqual([], result)
+
+    def test_complete_proofreading_result_is_kept(self):
+        main.groq.run_groq_model = lambda groq_api_key, model, options: (
+            "Tytuł: News\n\n"
+            "Podsumowanie: Tekst jest kompletny.\n\n"
+            f"Link: {ARTICLE_URL}"
+        )
+
+        result = main.news_proofreading(
+            {"GROQ_API": "test", "LLM_MODEL": "model"},
+            [
+                "Tytuł: News\n\n"
+                "Podsumowanie: Szkic.\n\n"
+                f"Link: {ARTICLE_URL}\n\n"
+                "################################"
+            ],
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertIn("Tekst jest kompletny.", result[0])
+
+    def test_complete_proofreading_result_allows_closing_quote_after_sentence(self):
+        main.groq.run_groq_model = lambda groq_api_key, model, options: (
+            "Tytuł: News\n\n"
+            "Podsumowanie: Tekst jest kompletny.”\n\n"
+            f"Link: {ARTICLE_URL}"
+        )
+
+        result = main.news_proofreading(
+            {"GROQ_API": "test", "LLM_MODEL": "model"},
+            [
+                "Tytuł: News\n\n"
+                "Podsumowanie: Szkic.\n\n"
+                f"Link: {ARTICLE_URL}\n\n"
+                "################################"
+            ],
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertIn("Tekst jest kompletny.”", result[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add PRD 004 and Milestone 1.5 for resilient article fetching
- validate Jina responses and fallback to WordPress REST API/direct HTML for konsolowe.info
- block incomplete proofreading results before email delivery

## Tests
- uv run python -m unittest discover -s tests -p "test_*.py"
- live smoke run confirmed email delivery for the recovered article