### PR TITLE
Migracja źródła newsów na PPE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,12 @@
 GROQ_API_KEY="gsk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 LLM_MODEL="qwen/qwen3.6-27b"
 
+# Listing
+URL="https://www.ppe.pl/gry"
+
 # Google Sheets
-GOOGLE_SHEET_ID="1o0htAcR-8ej4u9GiRCYHxxvFKE7BhCaryB6nqkM-KTI"
-GOOGLE_SHEET_WORKSHEET="Arkusz1"
+GOOGLE_SHEET_ID="1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk"
+GOOGLE_SHEET_WORKSHEET="Sheet1"
 GSPREAD_SERVICE_ACCOUNT_FILE="service_account.json"
 
 # Email

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skrypt do podsumowywania newsow z branzy gier.
 
 ## Jak to dziala
 
-Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML strony listingu, a nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), a jesli Jina zwroci blad lub niewiarygodna tresc dla `konsolowe.info`, aplikacja uzywa fallbacku przez WordPress REST API albo bezposredni HTML artykulu. Nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a kompletny wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`. Domyslnym modelem jest `qwen/qwen3.6-27b`.
+Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista kandydatow do przetworzenia jest wyciagana bezposrednio z HTML listingu `https://www.ppe.pl/gry`; parser bierze tylko linki newsow PPE w formacie `/news/<id>/<slug>.html`. Nowe linki sa zapisywane do arkusza przed dalszym przetwarzaniem. Pelna tresc artykulu jest pobierana przez mirror [Jina AI](https://jina.ai), a jesli Jina zwroci blad lub niewiarygodna tresc dla historycznych linkow z `konsolowe.info`, aplikacja uzywa fallbacku przez WordPress REST API albo bezposredni HTML artykulu. Nastepnie model Groq wskazany w `LLM_MODEL` przygotowuje podsumowanie i korekte, a kompletny wynik trafia do zbiorczego e-maila wysylanego jako multipart: stylowany HTML z fallbackiem `plain text`. Domyslnym modelem jest `qwen/qwen3.6-27b`.
 
 ## Wymagania
 
@@ -19,8 +19,9 @@ Skrypt wykorzystuje Google Sheets jako baze stanu przetworzonych linkow. Lista k
 2. Uzupelnij wartosci zmiennych:
    - `GROQ_API_KEY`
    - `LLM_MODEL` (domyslnie `qwen/qwen3.6-27b`)
-   - `GOOGLE_SHEET_ID`
-   - `GOOGLE_SHEET_WORKSHEET`
+   - `URL` (domyslnie `https://www.ppe.pl/gry`)
+   - `GOOGLE_SHEET_ID` (domyslnie arkusz `gameflash_sheet_ppe`: `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`)
+   - `GOOGLE_SHEET_WORKSHEET` (domyslnie `Sheet1`)
    - `GSPREAD_SERVICE_ACCOUNT_FILE`
    - `SMTP_SERVER`
    - `SENDER_MAIL`
@@ -49,7 +50,7 @@ Projekt uzywa `unittest`. Standardowa komenda:
 uv run python -m unittest discover -s tests -p "test_*.py"
 ```
 
-Testy obejmuja Google Sheets, parser listingu, finalny pipeline przetwarzania linkow w trybie stubowanym, fallback pobierania tresci artykulu oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
+Testy obejmuja Google Sheets, parser listingu PPE, finalny pipeline przetwarzania linkow w trybie stubowanym, fallback pobierania tresci artykulu oraz renderowanie i wysylke stylowanego e-maila HTML bez realnego SMTP.
 
 Opcjonalna walidacja live modelu Qwen, bez zapisu do Google Sheets i bez wysylki SMTP:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -171,3 +171,29 @@ Zakres:
 - integracja pomijania linku z obecnym etapem podsumowania
 - walidacja kompletności wyniku korekty przed wysylka
 - testy jednostkowe bez realnego IO dla bledow Jina, fallbacku i blokady LLM
+
+---
+
+## Milestone 1.6: Migracja zrodla newsow na PPE (done)
+
+Cel:
+- przejsc z listingu `konsolowe.info` na aktywne zrodlo `https://www.ppe.pl/gry`
+- uzyc nowego arkusza `gameflash_sheet_ppe` jako bazy stanu linkow PPE
+- zachowac dotychczasowy scenariusz przetwarzania linkow po zmianie zrodla
+
+Definition of Done:
+- domyslny URL listingu wskazuje `https://www.ppe.pl/gry`
+- domyslny `GOOGLE_SHEET_ID` wskazuje arkusz `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`
+- domyslny `GOOGLE_SHEET_WORKSHEET` wskazuje zakladke `Sheet1`
+- parser listingu zwraca tylko pelne URL newsow PPE pasujace do `/news/<id>/<slug>.html`
+- parser ignoruje linki `/gry/...`, rankingi, menu, `/news.html`, promocje i obce domeny
+- pierwszy przebieg na arkuszu zawierajacym tylko naglowek `Links` przetwarza widoczne newsy PPE
+- po udanym append do Google Sheets aplikacja zachowuje obecny przeplyw: Jina, podsumowanie, korekta i e-mail multipart
+- testy lokalne przechodza komenda `uv run python -m unittest discover -s tests -p "test_*.py"`
+
+Zakres:
+- zmiana domyslnej konfiguracji listingu i arkusza Google Sheets
+- dostosowanie parsera HTML do linkow PPE
+- normalizacja wzglednych linkow PPE do pelnych URL
+- aktualizacja testow jednostkowych parsera i pipeline'u pod nowe zrodlo
+- aktualizacja README oraz dokumentacji operacyjnej po implementacji

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,12 +4,14 @@
 - Glowny skrypt pobiera newsy, podsumowuje je i wysyla e-mail.
 - Zarzadzanie zaleznosciami zostalo przeniesione na `uv`.
 - Model LLM jest konfigurowany przez `LLM_MODEL` w `.env`; domyslnym modelem jest `qwen/qwen3.6-27b`.
-- Stan przetworzonych linkow jest odczytywany i zapisywany w Google Sheets.
-- Listing newsow jest parsowany bezposrednio z HTML bez uzycia LLM.
+- Stan przetworzonych linkow jest odczytywany i zapisywany w Google Sheets, domyslnie w arkuszu `gameflash_sheet_ppe`.
+- Listing newsow jest pobierany z `https://www.ppe.pl/gry` i parsowany bezposrednio z HTML bez uzycia LLM.
+- Parser listingu wyciaga tylko linki newsow PPE w formacie `/news/<id>/<slug>.html`.
 - Pelna tresc artykulow jest pobierana przez mirror Jina z fallbackiem przez WordPress REST API lub bezposredni HTML dla `konsolowe.info`.
+- Dlugie tresci artykulow sa przycinane przed promptem podsumowania, zeby ograniczyc ryzyko przekroczenia limitu wejscia modelu.
 - Wiadomosc e-mail jest wysylana jako multipart z fallbackiem `plain text` i stylowana warstwa HTML.
 - Niekompletne wyniki korekty LLM nie trafiaja do e-maila.
-- Testy `unittest` dla Milestone 1.0-1.5 przechodza lokalnie.
+- Testy `unittest` dla Milestone 1.0-1.6 przechodza lokalnie.
 
 ## Co jest skończone
 - Dodanie dokumentow operacyjnych repo.
@@ -20,6 +22,7 @@
 - Milestone 1.3: stylowany e-mail HTML dla GameFlash z fallbackiem `plain text`.
 - Milestone 1.4: migracja domyslnego modelu Groq na `qwen/qwen3.6-27b`, walidacja live Qwen i obsluga reasoning.
 - Milestone 1.5: odporne pobieranie tresci artykulow, fallback dla `konsolowe.info` i blokada niekompletnych korekt.
+- Milestone 1.6: migracja aktywnego zrodla newsow na PPE i arkusz `gameflash_sheet_ppe`.
 - Bazowy zestaw testow `unittest` dla Google Sheets i deduplikacji.
 - Aktualizacja bezposrednich zaleznosci do najnowszych kompatybilnych wersji.
 
@@ -34,6 +37,7 @@
 - Walidacja live Google Sheets zalezy od dostepu konta serwisowego do wskazanego arkusza.
 - Dalsze powodzenie pipeline'u zalezy od dostepnosci Google Sheets, strony z listingiem, mirroru Jina, Groq i SMTP.
 - Model `qwen/qwen3.6-27b` wymaga ukrycia reasoning i wiekszego budzetu tokenow, szczegolnie na etapie korekty, aby zwracac finalna tresc zamiast technicznego procesu rozumowania.
+- Link dopisany do Google Sheets przed bledem dalszego przetwarzania nie jest automatycznie ponawiany w kolejnym przebiegu.
 
 ## Ostatnie aktualizacje
 - 2026-03-21: migracja konfiguracji projektu na `uv`.
@@ -44,3 +48,5 @@
 - 2026-03-22: wdrozenie Milestone 1.3, stylowany e-mail HTML, fallback `plain text` i testy lokalne warstwy maili.
 - 2026-06-27: wdrozenie Milestone 1.4, domyslny model `qwen/qwen3.6-27b`, walidacja live Qwen, ukrycie reasoning i testy lokalne.
 - 2026-06-27: wdrozenie Milestone 1.5, walidacja blednych odpowiedzi Jina, fallback WordPress/HTML, blokada niekompletnych korekt, testy lokalne i walidacja live problematycznego artykulu.
+- 2026-06-29: wdrozenie Milestone 1.6, migracja listingu na `https://www.ppe.pl/gry`, arkusz `gameflash_sheet_ppe`, parser linkow PPE i testy lokalne.
+- 2026-06-29: poprawki po self-review: limit wejscia artykulu przed LLM, timeout klienta Groq oraz walidacja live wysylki maila dla 3 newsow PPE.

--- a/llms/groq.py
+++ b/llms/groq.py
@@ -6,6 +6,7 @@ from groq import Groq
 
 QWEN_REASONING_MODEL = "qwen/qwen3.6-27b"
 QWEN_MIN_MAX_TOKENS = 4096
+GROQ_REQUEST_TIMEOUT_SECONDS = 60.0
 THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL | re.IGNORECASE)
 OPEN_THINK_BLOCK_RE = re.compile(r"<think>.*\Z", re.DOTALL | re.IGNORECASE)
 
@@ -93,6 +94,7 @@ def groq_client(groq_api_key):
     """Inicjalizacja klienta Groq"""
     client = Groq(
         api_key=groq_api_key,
+        timeout=GROQ_REQUEST_TIMEOUT_SECONDS,
     )
     return client
 

--- a/main.py
+++ b/main.py
@@ -8,9 +8,15 @@ from llms import groq
 from scrapers import jina, listing
 from emails import gmail
 from storage import google_sheets
-from utils import utils
 
+DEFAULT_LISTING_URL = "https://www.ppe.pl/gry"
 DEFAULT_LLM_MODEL = "qwen/qwen3.6-27b"
+DEFAULT_GOOGLE_SHEET_ID = "1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk"
+DEFAULT_GOOGLE_SHEET_WORKSHEET = "Sheet1"
+MAX_ARTICLE_TEXT_CHARS = 10000
+ARTICLE_TRUNCATION_NOTICE = (
+    "\n\n[Pozostala czesc artykulu zostala pominieta ze wzgledu na limit wejscia modelu.]"
+)
 LINK_RE = re.compile(r"^Link:\s*(\S+)\s*$", re.MULTILINE)
 TITLE_RE = re.compile(r"^Tytu[łl]:\s*(.+)$", re.MULTILINE)
 SUMMARY_RE = re.compile(r"Podsumowanie:\s*(.+?)(?:\n\s*\nLink:|\nLink:|\Z)", re.DOTALL)
@@ -23,17 +29,17 @@ def load_config():
     """
     load_dotenv()
     return {
-        "URL": "https://konsolowe.info/playstation/ps5/",
+        "URL": os.getenv("URL", DEFAULT_LISTING_URL),
         "GROQ_API": os.getenv("GROQ_API_KEY"),
         "LLM_MODEL": os.getenv("LLM_MODEL", DEFAULT_LLM_MODEL),
         "SMTP_SERVER": os.getenv("SMTP_SERVER"),
         "SENDER_MAIL": os.getenv("SENDER_MAIL"),
         "SENDER_PASS": os.getenv("SENDER_PASS"),
         "RECIPIENTS": os.getenv("RECIPIENTS").split(","),
-        "GOOGLE_SHEET_ID": os.getenv(
-            "GOOGLE_SHEET_ID", "1o0htAcR-8ej4u9GiRCYHxxvFKE7BhCaryB6nqkM-KTI"
+        "GOOGLE_SHEET_ID": os.getenv("GOOGLE_SHEET_ID", DEFAULT_GOOGLE_SHEET_ID),
+        "GOOGLE_SHEET_WORKSHEET": os.getenv(
+            "GOOGLE_SHEET_WORKSHEET", DEFAULT_GOOGLE_SHEET_WORKSHEET
         ),
-        "GOOGLE_SHEET_WORKSHEET": os.getenv("GOOGLE_SHEET_WORKSHEET", "Arkusz1"),
         "GSPREAD_SERVICE_ACCOUNT_FILE": os.getenv(
             "GSPREAD_SERVICE_ACCOUNT_FILE", "service_account.json"
         ),
@@ -53,8 +59,7 @@ def fetch_and_process_news(config):
     registered_links = google_sheets.read_registered_links(ws)
 
     news = listing.fetch_listing_html(url=config["URL"])
-    year, month = utils.current_yera_and_month()
-    parse_news_response = listing.extract_news_links(news, year, month)
+    parse_news_response = listing.extract_news_links(news, base_url=config["URL"])
     new_links = []
     seen_this_run = set()
     for link in parse_news_response:
@@ -72,6 +77,16 @@ def fetch_and_process_news(config):
     return new_links
 
 
+def prepare_article_text_for_summary(article_text: str) -> str:
+    """Ogranicza wejscie do LLM, zeby nie przekroczyc limitu rozmiaru promptu."""
+    cleaned_text = str(article_text or "").strip()
+    if len(cleaned_text) <= MAX_ARTICLE_TEXT_CHARS:
+        return cleaned_text
+
+    trimmed_text = cleaned_text[:MAX_ARTICLE_TEXT_CHARS].rsplit(" ", 1)[0].rstrip()
+    return f"{trimmed_text}{ARTICLE_TRUNCATION_NOTICE}"
+
+
 def summarize_news(config, new_links):
     """
     Podsumowuje nowe linki do newsów i wysyła email z podsumowaniami.
@@ -79,7 +94,9 @@ def summarize_news(config, new_links):
     news_to_corrected = []
     for news in new_links:
         try:
-            read_news = jina.fetch_article_text(url=news)
+            read_news = prepare_article_text_for_summary(
+                jina.fetch_article_text(url=news)
+            )
             summary_model_options = groq.model_options(
                 prompt=groq.summary_prompt(read_news),
                 temperature=0.8,

--- a/prd/005-ppe-source-migration-prd.md
+++ b/prd/005-ppe-source-migration-prd.md
@@ -1,0 +1,187 @@
+# PRD 005: Migracja źródła newsów na PPE i nowy arkusz Google Sheets
+
+## Cel zmiany
+
+Celem tej zmiany jest przeniesienie aktywnego źródła newsów GameFlash z `konsolowe.info` na PPE, ponieważ dotychczasowa strona przestała dostarczać świeże treści w oczekiwanym rytmie.
+
+Po wdrożeniu GameFlash ma:
+- pobierać listing newsów z `https://www.ppe.pl/gry`,
+- wyciągać z listingu wyłącznie linki do newsów PPE,
+- zapisywać stan przetworzonych linków w arkuszu `gameflash_sheet_ppe`,
+- zachować dotychczasowy scenariusz przetwarzania: deduplikacja, append do Google Sheets, pobranie treści, podsumowanie, korekta i wysyłka e-maila,
+- nie mieszać newsów PPE z bazą gier, rankingami ani innymi linkami ze strony `/gry`.
+
+## Problem do rozwiązania
+
+Obecna implementacja jest skonfigurowana pod źródło `https://konsolowe.info/playstation/ps5/` i parser linków zgodny z adresem `https://konsolowe.info/<YYYY>/<MM>/...`.
+
+To podejście stało się problematyczne, ponieważ:
+- dotychczasowa strona praktycznie przestała publikować nowe newsy,
+- pipeline może regularnie kończyć się brakiem nowych treści,
+- parser linków jest związany ze strukturą URL `konsolowe.info`, której PPE nie używa,
+- nowy arkusz Google Sheets ma oddzielać stan przetwarzania PPE od historycznego stanu `konsolowe.info`.
+
+## Zakres funkcjonalny
+
+Zmiana obejmuje:
+- zmianę domyślnego URL listingu na `https://www.ppe.pl/gry`,
+- zmianę domyślnego arkusza Google Sheets na ID `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`,
+- zmianę domyślnej zakładki arkusza na `Sheet1`,
+- zachowanie kolumny `Links` jako źródła prawdy dla przetworzonych linków,
+- zmianę parsera listingu tak, aby wyciągał linki PPE w formacie `/news/<id>/<slug>.html`,
+- normalizację linków względnych PPE do pełnej postaci `https://www.ppe.pl/news/<id>/<slug>.html`,
+- ignorowanie linków do bazy gier, rankingów, menu, `/news.html`, promocji i innych sekcji,
+- zachowanie pierwszego przebiegu na pustym arkuszu jako normalnego przetwarzania widocznych newsów.
+
+## Poza zakresem
+
+Ta zmiana nie obejmuje:
+- obsługi wielu aktywnych źródeł newsów równocześnie,
+- importu historycznych linków z poprzedniego arkusza,
+- migracji danych ze starego arkusza do `gameflash_sheet_ppe`,
+- dodania dedykowanego fallbacku pobierania treści dla PPE,
+- zmiany modelu LLM,
+- zmiany promptów podsumowania i korekty,
+- zmiany renderowania e-maila HTML,
+- zmiany konfiguracji SMTP,
+- dodania nowych zależności,
+- przebudowy aplikacji na CLI, API albo usługę wieloźródłową.
+
+## Docelowy przepływ
+
+Docelowy przebieg po migracji źródła:
+
+1. Aplikacja ładuje konfigurację z `.env`.
+2. Aplikacja uwierzytelnia się do Google Sheets kontem serwisowym.
+3. Aplikacja otwiera arkusz o ID `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk` i zakładkę `Sheet1`, chyba że zmienne środowiskowe nadpiszą te wartości.
+4. Aplikacja odczytuje istniejące linki z kolumny `Links`.
+5. Aplikacja pobiera HTML strony `https://www.ppe.pl/gry`.
+6. Parser HTML wyciąga linki pasujące do wzorca PPE `/news/<id>/<slug>.html`.
+7. Linki względne są normalizowane do pełnych URL w domenie `https://www.ppe.pl`.
+8. Aplikacja usuwa duplikaty z bieżącego przebiegu i odrzuca linki obecne już w Google Sheets.
+9. Każdy nowy link jest najpierw dopisywany do arkusza.
+10. Dopiero po udanym append aplikacja pobiera pełną treść artykułu przez `https://r.jina.ai/<link>`.
+11. Aplikacja generuje podsumowanie, wykonuje korektę i wysyła zbiorczy e-mail multipart zgodnie z obecnym przepływem.
+
+## Wymagania techniczne
+
+### 1. Nowe źródło listingu
+
+Decyzja:
+- domyślny listing newsów ma wskazywać `https://www.ppe.pl/gry`.
+
+Uzasadnienie:
+- PPE publikuje aktywne newsy gamingowe, a dotychczasowe źródło przestało dostarczać świeże treści.
+
+Konsekwencje:
+- parser listingu musi zostać dostosowany do struktury PPE,
+- dokumentacja operacyjna musi wskazywać nowe aktywne źródło.
+
+### 2. Nowy arkusz Google Sheets
+
+Decyzja:
+- domyślnym arkuszem stanu ma być `gameflash_sheet_ppe` o ID `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`, zakładka `Sheet1`.
+
+Uzasadnienie:
+- nowy arkusz oddziela stan PPE od historycznego stanu poprzedniego źródła.
+
+Konsekwencje:
+- `GOOGLE_SHEET_ID` i `GOOGLE_SHEET_WORKSHEET` nadal mogą nadpisać domyślne wartości,
+- konto serwisowe musi mieć dostęp do nowego arkusza,
+- zakładka musi zawierać nagłówek `Links`.
+
+### 3. Parser linków PPE
+
+Decyzja:
+- parser ma zbierać wyłącznie linki do newsów PPE pasujące do wzorca `/news/<id>/<slug>.html`.
+
+Uzasadnienie:
+- strona `/gry` zawiera także bazę gier, rankingi, linki menu i inne treści, które nie są newsami do maila GameFlash.
+
+Konsekwencje:
+- linki `/gry/...`, `/news.html`, linki promocyjne, rankingi i nawigacja są ignorowane,
+- względne linki PPE muszą zostać zamienione na pełne URL,
+- deduplikacja w obrębie jednego przebiegu pozostaje wymagana.
+
+### 4. Pobieranie treści artykułu
+
+Decyzja:
+- dla PPE pierwszą ścieżką pobierania treści pozostaje Jina.
+
+Uzasadnienie:
+- sprawdzony przykładowy artykuł PPE zwraca przez Jina normalną treść tekstową z metadanymi i artykułem.
+
+Konsekwencje:
+- w ramach tej zmiany nie powstaje dedykowany fallback PPE,
+- istniejący fallback WordPress/HTML dla `konsolowe.info` pozostaje jako zachowanie historyczne i nie musi być usuwany.
+
+### 5. Pierwszy przebieg na pustym arkuszu
+
+Decyzja:
+- jeśli nowy arkusz zawiera tylko nagłówek `Links`, pierwszy przebieg ma normalnie przetworzyć i wysłać widoczne newsy PPE.
+
+Uzasadnienie:
+- użytkownik chce przejść na nowe źródło i zacząć otrzymywać bieżące newsy bez osobnego przebiegu inicjalizującego.
+
+Konsekwencje:
+- aplikacja nie ma trybu "tylko zarejestruj" dla pierwszego uruchomienia,
+- wszystkie widoczne, nowe linki `/news/` z listingu PPE mogą trafić do pierwszego maila.
+
+## Scenariusze akceptacyjne
+
+1. Nowy domyślny listing
+- jeśli `URL` nie jest nadpisany w konfiguracji, aplikacja pobiera listing z `https://www.ppe.pl/gry`.
+
+2. Nowy domyślny arkusz
+- jeśli `GOOGLE_SHEET_ID` i `GOOGLE_SHEET_WORKSHEET` nie są nadpisane, aplikacja używa arkusza `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk` i zakładki `Sheet1`.
+
+3. Ekstrakcja linków PPE
+- jeśli HTML zawiera linki `/news/<id>/<slug>.html`, parser zwraca pełne adresy `https://www.ppe.pl/news/<id>/<slug>.html`.
+
+4. Ignorowanie treści nienewsowych
+- jeśli HTML zawiera linki `/gry/...`, `/gry/ranking`, `/news.html` albo linki menu, parser ich nie zwraca.
+
+5. Deduplikacja
+- jeśli ten sam link PPE występuje wiele razy w HTML, do dalszego przetwarzania trafia tylko raz.
+
+6. Pomijanie linków istniejących w arkuszu
+- jeśli link PPE istnieje już w kolumnie `Links`, aplikacja nie pobiera artykułu i nie wysyła go ponownie.
+
+7. Pierwszy pusty arkusz
+- jeśli arkusz zawiera tylko nagłówek `Links`, aplikacja dopisuje i przetwarza widoczne linki PPE.
+
+8. Brak regresji pipeline'u
+- po udanym append linku PPE aplikacja zachowuje dotychczasowy przepływ: Jina, podsumowanie, korekta i e-mail multipart.
+
+## Testy i scenariusze walidacyjne
+
+Implementacja wynikająca z tego PRD ma zostać pokryta testami `unittest` bez realnego IO.
+
+Testy powinny weryfikować co najmniej:
+- parser zwraca pełne URL dla linków PPE `/news/<id>/<slug>.html`,
+- parser ignoruje linki `/gry/...`, rankingi, menu, `/news.html` i obce domeny,
+- parser usuwa duplikaty w kolejności wystąpienia,
+- pipeline przetwarza nowy link PPE po udanym append do Google Sheets,
+- pipeline pomija link PPE obecny już w kolumnie `Links`,
+- błąd append do Google Sheets nadal blokuje dalsze przetwarzanie linku,
+- pierwszy pusty arkusz przetwarza widoczne linki PPE,
+- standardowe testy nie wykonują realnego SMTP,
+- standardowe testy nie zapisują danych do Google Sheets,
+- standardowe testy nie zależą od dostępności PPE, Jina ani Groq.
+
+Standardowa komenda testów pozostaje:
+
+```bash
+uv run python -m unittest discover -s tests -p "test_*.py"
+```
+
+## Założenia
+
+- Aktywnym źródłem GameFlash ma być PPE.
+- Strona `https://www.ppe.pl/gry` jest listingiem, z którego pobierane są linki do newsów.
+- Tylko linki `/news/<id>/<slug>.html` są traktowane jako newsy do maila.
+- Nowy arkusz `gameflash_sheet_ppe` istnieje i jest dostępny dla konta serwisowego.
+- Zakładka `Sheet1` zawiera nagłówek `Links`.
+- Pierwszy przebieg na nowym arkuszu ma wysłać widoczne newsy, a nie tylko zainicjalizować stan.
+- Obecna architektura skryptowa pozostaje właściwa i nie wymaga przebudowy.
+- PRD opisuje przyszłą poprawkę implementacyjną, ale samo dodanie dokumentu nie zmienia działania aplikacji.

--- a/scrapers/listing.py
+++ b/scrapers/listing.py
@@ -1,7 +1,13 @@
 """Pobieranie i parsowanie listingu newsow."""
 
+import re
+from urllib.parse import urljoin, urlparse
+
 from bs4 import BeautifulSoup
 import requests
+
+PPE_BASE_URL = "https://www.ppe.pl"
+PPE_NEWS_PATH_RE = re.compile(r"^/news/\d+/[^/]+\.html$")
 
 
 def fetch_listing_html(url: str) -> str:
@@ -11,18 +17,29 @@ def fetch_listing_html(url: str) -> str:
     return response.text
 
 
-def extract_news_links(html: str, year: int, month: str) -> list[str]:
-    """Wyciaga linki do artykulow dla biezacego roku i miesiaca."""
-    prefix = f"https://konsolowe.info/{year}/{month}/"
+def extract_news_links(html: str, base_url: str = PPE_BASE_URL) -> list[str]:
+    """Wyciaga linki do newsow PPE z listingu i normalizuje je do pelnych URL."""
     soup = BeautifulSoup(html, "html.parser")
     links = []
     seen = set()
 
-    for anchor in soup.select(f'a[href^="{prefix}"]'):
-        link = str(anchor.get("href", "")).strip()
-        if not link or link in seen:
+    for anchor in soup.select("a[href]"):
+        href = str(anchor.get("href", "")).strip()
+        if not href:
             continue
-        seen.add(link)
-        links.append(link)
+
+        link = urljoin(base_url, href)
+        parsed_link = urlparse(link)
+        parsed_base = urlparse(base_url)
+        if parsed_link.netloc != parsed_base.netloc:
+            continue
+        if not PPE_NEWS_PATH_RE.match(parsed_link.path):
+            continue
+
+        normalized_link = f"{parsed_base.scheme}://{parsed_base.netloc}{parsed_link.path}"
+        if normalized_link in seen:
+            continue
+        seen.add(normalized_link)
+        links.append(normalized_link)
 
     return links

--- a/spec.md
+++ b/spec.md
@@ -48,6 +48,14 @@ Planowane rozszerzenie zakresu wynikające z PRD `004-article-content-fetch-resi
 
 Rozszerzenie z PRD `004-article-content-fetch-resilience-prd.md` zostalo wdrozone.
 
+Planowane rozszerzenie zakresu wynikające z PRD `005-ppe-source-migration-prd.md`:
+- zmiana aktywnego źródła listingu newsów na `https://www.ppe.pl/gry`,
+- zmiana domyślnego arkusza stanu na `gameflash_sheet_ppe`,
+- dostosowanie parsera HTML do linków PPE w formacie `/news/<id>/<slug>.html`,
+- zachowanie dotychczasowego scenariusza deduplikacji, pobierania treści, podsumowania, korekty i wysyłki e-maila.
+
+Rozszerzenie z PRD `005-ppe-source-migration-prd.md` zostalo wdrozone.
+
 ---
 
 ## Zakres funkcjonalny (high-level)
@@ -113,6 +121,19 @@ Docelowy przeplyw wynikajacy z PRD `004-article-content-fetch-resilience-prd.md`
 6. Jesli zadna sciezka nie dostarczy realnej tresci, aplikacja pomija link i nie wywoluje LLM.
 7. Wynik korekty jezykowej jest sprawdzany pod katem kompletnosci przed dodaniem do maila.
 
+Docelowy przeplyw wynikajacy z PRD `005-ppe-source-migration-prd.md`:
+1. Aplikacja laduje konfiguracje z `.env`.
+2. Aplikacja uwierzytelnia sie do Google Sheets kontem serwisowym.
+3. Aplikacja domyslnie otwiera arkusz `gameflash_sheet_ppe` o ID `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk` i zakladke `Sheet1`.
+4. Aplikacja odczytuje istniejace linki z kolumny `Links`.
+5. Aplikacja pobiera HTML listingu `https://www.ppe.pl/gry`.
+6. Parser HTML wyciaga tylko linki PPE pasujace do wzorca `/news/<id>/<slug>.html`.
+7. Linki wzgledne sa normalizowane do pelnych URL w domenie `https://www.ppe.pl`.
+8. Aplikacja usuwa duplikaty z biezacego przebiegu i odrzuca linki obecne juz w Google Sheets.
+9. Kazdy nowy link jest najpierw dopisywany do Google Sheets.
+10. Dopiero po udanym append aplikacja pobiera tresc artykulu przez `https://r.jina.ai/<link>`.
+11. Aplikacja zachowuje obecny przeplyw podsumowania, korekty i wysylki e-maila multipart.
+
 Czego aplikacja obecnie nie robi:
 - nie waliduje kompleksowo konfiguracji przed startem,
 - nie obsługuje wielu źródeł wejściowych ani wielu modeli,
@@ -149,6 +170,11 @@ Planowane rozszerzenie komponentow wynikajace z PRD `004-article-content-fetch-r
 - warstwa pobierania tresci ma dostac fallback dla `konsolowe.info` oparty o WordPress REST API lub bezposredni HTML,
 - `main.py` ma pomijac linki, dla ktorych nie udalo sie pobrac wiarygodnej tresci,
 - etap korekty ma weryfikowac kompletnosc wyniku przed przekazaniem newsa do warstwy mailowej.
+
+Planowane rozszerzenie komponentow wynikajace z PRD `005-ppe-source-migration-prd.md`:
+- `main.py` ma domyslnie wskazywac listing PPE oraz nowy arkusz Google Sheets,
+- `scrapers/listing.py` ma wyciagac i normalizowac linki PPE typu `/news/<id>/<slug>.html`,
+- `storage/google_sheets.py` pozostaje bez zmiany kontraktu: zrodlem prawdy nadal jest kolumna `Links`.
 
 2. Przepływ danych między komponentami
 - Wejście konfiguracyjne pochodzi z `.env` i stałych zaszytych w `main.py`.
@@ -189,6 +215,13 @@ Docelowy przeplyw danych wynikajacy z PRD `004-article-content-fetch-resilience-
 - brak realnej tresci artykulu konczy przetwarzanie danego linku przed etapem LLM,
 - niekompletny wynik korekty nie trafia do reprezentacji `plain text` ani `html`.
 
+Docelowy przeplyw danych wynikajacy z PRD `005-ppe-source-migration-prd.md`:
+- domyslne wejscie listingu zmienia sie na `https://www.ppe.pl/gry`,
+- domyslna konfiguracja Google Sheets wskazuje arkusz `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk` i zakladke `Sheet1`,
+- parser listingu ignoruje linki do bazy gier, rankingow, menu i innych sekcji PPE,
+- parser zwraca tylko pelne URL newsow PPE w formacie `https://www.ppe.pl/news/<id>/<slug>.html`,
+- pobieranie tresci artykulu dla linkow PPE nadal zaczyna sie od mirrora Jina.
+
 3. Granice odpowiedzialności
 - Logika przepływu pozostaje w `main.py`.
 - Integracje z zewnętrznymi usługami są rozdzielone na moduły `scrapers`, `llms` i `emails`.
@@ -213,6 +246,11 @@ Po wdrozeniu PRD `004-article-content-fetch-resilience-prd.md`:
 - warstwa pobierania tresci odrzuca strony bledow i uruchamia fallback,
 - warstwa LLM nadal odpowiada wylacznie za podsumowanie i korekte realnej tresci artykulu,
 - warstwa maili nie przyjmuje niekompletnych wynikow korekty.
+
+Po wdrozeniu PRD `005-ppe-source-migration-prd.md`:
+- aktywnym zrodlem listingu bedzie PPE,
+- warstwa deduplikacji i zapisu linkow nadal bedzie oparta o Google Sheets,
+- dotychczasowy fallback dla `konsolowe.info` pozostanie zachowaniem historycznym, a nie wymaganiem dla nowego zrodla.
 
 ---
 
@@ -263,7 +301,16 @@ Rozszerzenia techniczne po wdrozeniu PRD `004-article-content-fetch-resilience-p
 - fallback probuje pobrac tresc przez WordPress REST API, a potem przez bezposredni HTML artykulu,
 - wynik korekty musi zawierac tytul, podsumowanie, link i domkniete zdanie,
 - korekta Qwen uzywa nizszej temperatury i wyzszego budzetu tokenow, aby ograniczyc ryzyko pustych lub ucietych odpowiedzi,
+- tresc artykulu przekazywana do promptu podsumowania jest ograniczana do ustalonego limitu znakow, z jawnym dopiskiem o pominietej dalszej czesci,
+- klient Groq uzywa timeoutu zadania, zeby pojedyncze wywolanie API nie blokowalo procesu bez konca,
 - nie dodano nowych zaleznosci wykonawczych.
+
+Planowane rozszerzenia techniczne wynikajace z PRD `005-ppe-source-migration-prd.md`:
+- zmiana domyslnego URL listingu na `https://www.ppe.pl/gry`,
+- zmiana domyslnego `GOOGLE_SHEET_ID` na `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`,
+- zmiana domyslnego `GOOGLE_SHEET_WORKSHEET` na `Sheet1`,
+- zmiana parsera linkow z miesiecznego wzorca `konsolowe.info` na wzorzec PPE `/news/<id>/<slug>.html`,
+- brak nowych zaleznosci wykonawczych.
 
 ---
 
@@ -383,6 +430,26 @@ Każda decyzja powinna zawierać:
 - Uzasadnienie: Milestone 1.2 zakladal Jina jako sciezke pobierania tresci, ale zaobserwowano przypadek, w ktorym Jina zwrocila blad zrodla jako tresc odpowiedzi `HTTP 200`.
 - Konsekwencje: Jina pozostaje pierwsza proba pobrania tresci, ale nie bedzie jedynym ani bezwarunkowo zaufanym zrodlem tresci artykulu.
 
+- Decyzja (dotyczy PRD: `005-ppe-source-migration-prd.md`): aktywnym zrodlem listingu newsow ma zostac `https://www.ppe.pl/gry`.
+- Uzasadnienie: dotychczasowe zrodlo `konsolowe.info` przestalo dostarczac swieze newsy w oczekiwanym rytmie.
+- Konsekwencje: parser listingu musi zostac dostosowany do struktury PPE, a dokumentacja operacyjna ma wskazywac nowe aktywne zrodlo.
+
+- Decyzja (dotyczy PRD: `005-ppe-source-migration-prd.md`): domyslnym arkuszem stanu ma zostac `gameflash_sheet_ppe` o ID `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk`, zakladka `Sheet1`.
+- Uzasadnienie: nowy arkusz oddziela stan przetwarzania PPE od historycznego stanu poprzedniego zrodla.
+- Konsekwencje: `GOOGLE_SHEET_ID` i `GOOGLE_SHEET_WORKSHEET` nadal moga nadpisac domyslne wartosci, ale konto serwisowe musi miec dostep do nowego arkusza z kolumna `Links`.
+
+- Decyzja (dotyczy PRD: `005-ppe-source-migration-prd.md`): parser PPE ma zwracac wylacznie linki newsowe pasujace do `/news/<id>/<slug>.html`.
+- Uzasadnienie: strona `https://www.ppe.pl/gry` zawiera rowniez baze gier, rankingi, menu i linki promocyjne, ktore nie sa newsami do maila GameFlash.
+- Konsekwencje: linki `/gry/...`, `/news.html`, rankingi i nawigacja sa ignorowane, a wzgledne linki newsow sa normalizowane do pelnych URL w domenie `https://www.ppe.pl`.
+
+- Decyzja (dotyczy PRD: `005-ppe-source-migration-prd.md`): pierwszy przebieg na pustym arkuszu PPE ma normalnie przetworzyc widoczne newsy.
+- Uzasadnienie: celem migracji jest natychmiastowe przejscie na aktywne zrodlo, bez osobnego trybu inicjalizacji stanu.
+- Konsekwencje: jesli arkusz zawiera tylko naglowek `Links`, wszystkie widoczne, nowe linki `/news/` z listingu PPE moga trafic do pierwszego maila.
+
+- Konflikt specyfikacji (dotyczy PRD: `005-ppe-source-migration-prd.md`): PRD zmienia historyczne zalozenie, ze parser linkow opiera sie na wzorcu `https://konsolowe.info/<YYYY>/<MM>/`.
+- Uzasadnienie: PPE nie koduje roku i miesiaca w linkach newsow, dlatego dotychczasowy selektor miesieczny nie moze obslugiwac nowego aktywnego zrodla.
+- Konsekwencje: po wdrozeniu PRD `005-ppe-source-migration-prd.md` aktywny parser ma byc zgodny z PPE, a wzorzec `konsolowe.info` pozostaje elementem historycznego opisu poprzedniego zrodla.
+
 ---
 
 ## Jakość i kryteria akceptacji
@@ -437,6 +504,17 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `004-article-content-fetch-
 - niekompletny wynik korekty nie jest wysylany w mailu HTML ani `plain text`,
 - testy jednostkowe pokrywaja bledna odpowiedz Jina, fallback i brak realnego IO.
 
+Minimalne kryteria akceptacji dla rozszerzenia z PRD `005-ppe-source-migration-prd.md`:
+- aplikacja domyslnie pobiera listing z `https://www.ppe.pl/gry`,
+- aplikacja domyslnie uzywa arkusza `1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk` i zakladki `Sheet1`,
+- parser zwraca pelne URL dla linkow PPE `/news/<id>/<slug>.html`,
+- parser ignoruje linki `/gry/...`, rankingi, menu, `/news.html` i obce domeny,
+- link obecny juz w kolumnie `Links` nie jest przetwarzany ponownie,
+- nowy link PPE jest dopisywany do Google Sheets przed pobraniem tresci artykulu,
+- pierwszy pusty arkusz PPE przetwarza widoczne newsy zamiast tylko inicjalizowac stan,
+- testy jednostkowe pokrywaja parser PPE, limit wejscia artykulu, timeout Groq i nowy przeplyw bez realnego IO,
+- walidacja live potwierdza wysylke zbiorczego maila dla 3 newsow PPE.
+
 ---
 
 ## Zasady zmian i ewolucji
@@ -455,11 +533,12 @@ Minimalne kryteria akceptacji dla rozszerzenia z PRD `004-article-content-fetch-
 - PRD `002-gaming-email-styles-prd.md` wprowadza kolejny przyrost funkcjonalny: przejscie z maila `plain text` na stylowana wiadomosc HTML z fallbackiem `plain text`.
 - PRD `003-qwen-model-migration-prd.md` wprowadza kolejny przyrost funkcjonalny: migracje domyslnego modelu Groq na `qwen/qwen3.6-27b` wraz z walidacja live ryzyka reasoning.
 - PRD `004-article-content-fetch-resilience-prd.md` wprowadza kolejny przyrost funkcjonalny: odporne pobieranie tresci artykulow, fallback dla `konsolowe.info` i blokade podsumowan z blednych zrodel.
-- Milestone 1.0, 1.1, 1.2, 1.3, 1.4 i 1.5 sa wdrozone.
+- PRD `005-ppe-source-migration-prd.md` wprowadza kolejny przyrost funkcjonalny: migracje aktywnego zrodla newsow na PPE i nowy arkusz Google Sheets.
+- Milestone 1.0, 1.1, 1.2, 1.3, 1.4, 1.5 i 1.6 sa wdrozone.
 
 ---
 
 ## Status specyfikacji
 - Data utworzenia: 2026-03-21
-- Ostatnia aktualizacja: 2026-06-27
-- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.5 i domknieciu PRD `004-article-content-fetch-resilience-prd.md`
+- Ostatnia aktualizacja: 2026-06-29
+- Aktualny zakres obowiązywania: stan repo po wdrozeniu Milestone 1.6 i domknieciu PRD `005-ppe-source-migration-prd.md`

--- a/tests/test_listing.py
+++ b/tests/test_listing.py
@@ -4,25 +4,31 @@ from scrapers import listing
 
 
 class ListingParserTests(unittest.TestCase):
-    def test_extract_news_links_filters_current_month_and_deduplicates(self):
+    def test_extract_news_links_returns_ppe_news_links_and_deduplicates(self):
         html = """
         <html>
             <body>
-                <a href="https://konsolowe.info/2026/03/alpha/">Alpha</a>
-                <a href="https://konsolowe.info/2026/03/beta/">Beta</a>
-                <a href="https://konsolowe.info/2026/02/old/">Old</a>
+                <a href="/news/416209/assetto-corsa-rally.html">Alpha</a>
+                <a href="https://www.ppe.pl/news/416220/koei-tecmo.html">Beta</a>
+                <a href="/promocje">Promocje</a>
+                <a href="/promocje/gry/ps5">Promocje PS5</a>
+                <a href="/gry/ranking">Ranking</a>
+                <a href="/gry/the-path-of-the-warrior-art-of-fighting-3-r/20892">Game</a>
+                <a href="/news.html">News index</a>
+                <a href="/recenzje-gier.html">Recenzje</a>
+                <a href="/publicystyka.html">Publicystyka</a>
                 <a href="https://example.com/other/">Other</a>
-                <a href="https://konsolowe.info/2026/03/alpha/">Alpha duplicate</a>
+                <a href="/news/416209/assetto-corsa-rally.html">Alpha duplicate</a>
             </body>
         </html>
         """
 
         self.assertEqual(
             [
-                "https://konsolowe.info/2026/03/alpha/",
-                "https://konsolowe.info/2026/03/beta/",
+                "https://www.ppe.pl/news/416209/assetto-corsa-rally.html",
+                "https://www.ppe.pl/news/416220/koei-tecmo.html",
             ],
-            listing.extract_news_links(html, 2026, "03"),
+            listing.extract_news_links(html),
         )
 
 

--- a/tests/test_milestone_1_0.py
+++ b/tests/test_milestone_1_0.py
@@ -20,13 +20,41 @@ class FakeWorksheet:
 
 
 class MilestoneOneTests(unittest.TestCase):
+    def test_load_config_uses_ppe_defaults(self):
+        original_load_dotenv = main.load_dotenv
+        original_env = dict(main.os.environ)
+        try:
+            main.load_dotenv = lambda: None
+            main.os.environ.clear()
+            main.os.environ.update(
+                {
+                    "GROQ_API_KEY": "test",
+                    "SMTP_SERVER": "smtp.gmail.com",
+                    "SENDER_MAIL": "sender@example.com",
+                    "SENDER_PASS": "pass",
+                    "RECIPIENTS": "receiver@example.com",
+                }
+            )
+
+            config = main.load_config()
+
+            self.assertEqual("https://www.ppe.pl/gry", config["URL"])
+            self.assertEqual(
+                "1N82WxjskvsIyjlfwh8CxlhHJB9LEUMwbAdCI8w0J_yk",
+                config["GOOGLE_SHEET_ID"],
+            )
+            self.assertEqual("Sheet1", config["GOOGLE_SHEET_WORKSHEET"])
+        finally:
+            main.load_dotenv = original_load_dotenv
+            main.os.environ.clear()
+            main.os.environ.update(original_env)
+
     def test_fetch_and_process_news_uses_sheets_for_deduplication(self):
         worksheet = FakeWorksheet(values=[["Links"], ["https://example.com/existing"]])
 
         original_authenticate = main.google_sheets.authenticate_gspread
         original_open_sheet = main.google_sheets.open_sheet
         original_fetch_listing = main.listing.fetch_listing_html
-        original_current_year_month = main.utils.current_yera_and_month
         try:
             main.google_sheets.authenticate_gspread = lambda _: object()
             main.google_sheets.open_sheet = lambda gc, spreadsheet_id, worksheet_title: (
@@ -38,14 +66,13 @@ class MilestoneOneTests(unittest.TestCase):
             <a href="https://example.com/new">New</a>
             <a href="https://example.com/new">New duplicate</a>
             """
-            main.utils.current_yera_and_month = lambda: (2026, "03")
 
             new_links = main.fetch_and_process_news(
                 {
                     "GSPREAD_SERVICE_ACCOUNT_FILE": "service_account.json",
                     "GOOGLE_SHEET_ID": "sheet-id",
-                    "GOOGLE_SHEET_WORKSHEET": "Arkusz1",
-                    "URL": "https://konsolowe.info/playstation/ps5/",
+                    "GOOGLE_SHEET_WORKSHEET": "Sheet1",
+                    "URL": "https://www.ppe.pl/gry",
                 }
             )
 
@@ -54,15 +81,15 @@ class MilestoneOneTests(unittest.TestCase):
             main.google_sheets.authenticate_gspread = original_authenticate
             main.google_sheets.open_sheet = original_open_sheet
             main.listing.fetch_listing_html = original_fetch_listing
-            main.utils.current_yera_and_month = original_current_year_month
 
     def test_fetch_and_process_news_uses_html_parser_without_llm(self):
-        worksheet = FakeWorksheet(values=[["Links"], ["https://konsolowe.info/2026/03/existing/"]])
+        worksheet = FakeWorksheet(
+            values=[["Links"], ["https://www.ppe.pl/news/416200/existing.html"]]
+        )
 
         original_authenticate = main.google_sheets.authenticate_gspread
         original_open_sheet = main.google_sheets.open_sheet
         original_fetch_listing = main.listing.fetch_listing_html
-        original_current_year_month = main.utils.current_yera_and_month
         original_run_model = main.groq.run_groq_model
         try:
             main.google_sheets.authenticate_gspread = lambda _: object()
@@ -71,12 +98,11 @@ class MilestoneOneTests(unittest.TestCase):
                 worksheet,
             )
             main.listing.fetch_listing_html = lambda url: """
-            <a href="https://konsolowe.info/2026/03/existing/">Existing</a>
-            <a href="https://konsolowe.info/2026/03/new/">New</a>
-            <a href="https://konsolowe.info/2026/02/old/">Old</a>
-            <a href="https://konsolowe.info/2026/03/new/">New duplicate</a>
+            <a href="/news/416200/existing.html">Existing</a>
+            <a href="/news/416201/new.html">New</a>
+            <a href="/gry/sample-game/123">Game</a>
+            <a href="/news/416201/new.html">New duplicate</a>
             """
-            main.utils.current_yera_and_month = lambda: (2026, "03")
             main.groq.run_groq_model = lambda *args, **kwargs: (_ for _ in ()).throw(
                 AssertionError("LLM nie powinien byc wywolywany dla listingu")
             )
@@ -85,14 +111,14 @@ class MilestoneOneTests(unittest.TestCase):
                 {
                     "GSPREAD_SERVICE_ACCOUNT_FILE": "service_account.json",
                     "GOOGLE_SHEET_ID": "sheet-id",
-                    "GOOGLE_SHEET_WORKSHEET": "Arkusz1",
-                    "URL": "https://konsolowe.info/playstation/ps5/",
+                    "GOOGLE_SHEET_WORKSHEET": "Sheet1",
+                    "URL": "https://www.ppe.pl/gry",
                 }
             )
 
-            self.assertEqual(["https://konsolowe.info/2026/03/new/"], new_links)
+            self.assertEqual(["https://www.ppe.pl/news/416201/new.html"], new_links)
             self.assertEqual(
-                [("https://konsolowe.info/2026/03/new/", "RAW")],
+                [("https://www.ppe.pl/news/416201/new.html", "RAW")],
                 worksheet.appended_links,
             )
         finally:
@@ -100,18 +126,13 @@ class MilestoneOneTests(unittest.TestCase):
             main.google_sheets.open_sheet = original_open_sheet
             main.groq.run_groq_model = original_run_model
             main.listing.fetch_listing_html = original_fetch_listing
-            main.utils.current_yera_and_month = original_current_year_month
 
-    def test_fetch_and_process_news_skips_link_when_append_fails(self):
-        worksheet = FakeWorksheet(
-            values=[["Links"]],
-            append_fail_for={"https://konsolowe.info/2026/03/fail/"},
-        )
+    def test_fetch_and_process_news_normalizes_links_with_configured_url(self):
+        worksheet = FakeWorksheet(values=[["Links"]])
 
         original_authenticate = main.google_sheets.authenticate_gspread
         original_open_sheet = main.google_sheets.open_sheet
         original_fetch_listing = main.listing.fetch_listing_html
-        original_current_year_month = main.utils.current_yera_and_month
         try:
             main.google_sheets.authenticate_gspread = lambda _: object()
             main.google_sheets.open_sheet = lambda gc, spreadsheet_id, worksheet_title: (
@@ -119,30 +140,68 @@ class MilestoneOneTests(unittest.TestCase):
                 worksheet,
             )
             main.listing.fetch_listing_html = lambda url: """
-            <a href="https://konsolowe.info/2026/03/fail/">Fail</a>
-            <a href="https://konsolowe.info/2026/03/success/">Success</a>
+            <a href="/news/416204/from-config.html">From config</a>
             """
-            main.utils.current_yera_and_month = lambda: (2026, "03")
 
             new_links = main.fetch_and_process_news(
                 {
                     "GSPREAD_SERVICE_ACCOUNT_FILE": "service_account.json",
                     "GOOGLE_SHEET_ID": "sheet-id",
-                    "GOOGLE_SHEET_WORKSHEET": "Arkusz1",
-                    "URL": "https://konsolowe.info/playstation/ps5/",
+                    "GOOGLE_SHEET_WORKSHEET": "Sheet1",
+                    "URL": "https://www.ppe.pl/gry",
                 }
             )
 
-            self.assertEqual(["https://konsolowe.info/2026/03/success/"], new_links)
             self.assertEqual(
-                [("https://konsolowe.info/2026/03/success/", "RAW")],
+                ["https://www.ppe.pl/news/416204/from-config.html"], new_links
+            )
+            self.assertEqual(
+                [("https://www.ppe.pl/news/416204/from-config.html", "RAW")],
                 worksheet.appended_links,
             )
         finally:
             main.google_sheets.authenticate_gspread = original_authenticate
             main.google_sheets.open_sheet = original_open_sheet
             main.listing.fetch_listing_html = original_fetch_listing
-            main.utils.current_yera_and_month = original_current_year_month
+
+    def test_fetch_and_process_news_skips_link_when_append_fails(self):
+        worksheet = FakeWorksheet(
+            values=[["Links"]],
+            append_fail_for={"https://www.ppe.pl/news/416202/fail.html"},
+        )
+
+        original_authenticate = main.google_sheets.authenticate_gspread
+        original_open_sheet = main.google_sheets.open_sheet
+        original_fetch_listing = main.listing.fetch_listing_html
+        try:
+            main.google_sheets.authenticate_gspread = lambda _: object()
+            main.google_sheets.open_sheet = lambda gc, spreadsheet_id, worksheet_title: (
+                object(),
+                worksheet,
+            )
+            main.listing.fetch_listing_html = lambda url: """
+            <a href="/news/416202/fail.html">Fail</a>
+            <a href="/news/416203/success.html">Success</a>
+            """
+
+            new_links = main.fetch_and_process_news(
+                {
+                    "GSPREAD_SERVICE_ACCOUNT_FILE": "service_account.json",
+                    "GOOGLE_SHEET_ID": "sheet-id",
+                    "GOOGLE_SHEET_WORKSHEET": "Sheet1",
+                    "URL": "https://www.ppe.pl/gry",
+                }
+            )
+
+            self.assertEqual(["https://www.ppe.pl/news/416203/success.html"], new_links)
+            self.assertEqual(
+                [("https://www.ppe.pl/news/416203/success.html", "RAW")],
+                worksheet.appended_links,
+            )
+        finally:
+            main.google_sheets.authenticate_gspread = original_authenticate
+            main.google_sheets.open_sheet = original_open_sheet
+            main.listing.fetch_listing_html = original_fetch_listing
 
 
 if __name__ == "__main__":

--- a/tests/test_milestone_1_2.py
+++ b/tests/test_milestone_1_2.py
@@ -25,7 +25,6 @@ class PipelineTests(unittest.TestCase):
         self.original_authenticate = main.google_sheets.authenticate_gspread
         self.original_open_sheet = main.google_sheets.open_sheet
         self.original_fetch_listing = main.listing.fetch_listing_html
-        self.original_current_year_month = main.utils.current_yera_and_month
         self.original_fetch_article = main.jina.fetch_article_text
         self.original_run_model = main.groq.run_groq_model
         self.original_send_email = main.gmail.send_email
@@ -35,7 +34,6 @@ class PipelineTests(unittest.TestCase):
         main.google_sheets.authenticate_gspread = self.original_authenticate
         main.google_sheets.open_sheet = self.original_open_sheet
         main.listing.fetch_listing_html = self.original_fetch_listing
-        main.utils.current_yera_and_month = self.original_current_year_month
         main.jina.fetch_article_text = self.original_fetch_article
         main.groq.run_groq_model = self.original_run_model
         main.gmail.send_email = self.original_send_email
@@ -46,8 +44,8 @@ class PipelineTests(unittest.TestCase):
         main.load_config = lambda: {
             "GSPREAD_SERVICE_ACCOUNT_FILE": "service_account.json",
             "GOOGLE_SHEET_ID": "sheet-id",
-            "GOOGLE_SHEET_WORKSHEET": "Arkusz1",
-            "URL": "https://konsolowe.info/playstation/ps5/",
+            "GOOGLE_SHEET_WORKSHEET": "Sheet1",
+            "URL": "https://www.ppe.pl/gry",
             "GROQ_API": "test",
             "LLM_MODEL": "model",
             "SMTP_SERVER": "smtp.gmail.com",
@@ -61,7 +59,6 @@ class PipelineTests(unittest.TestCase):
             worksheet,
         )
         main.listing.fetch_listing_html = lambda url: listing_html
-        main.utils.current_yera_and_month = lambda: (2026, "03")
         main.gmail.send_email = lambda **kwargs: sent_messages.append(kwargs)
 
         return sent_messages
@@ -70,14 +67,14 @@ class PipelineTests(unittest.TestCase):
         worksheet = FakeWorksheet(values=[["Links"]])
         sent_messages = self._configure_common(
             worksheet,
-            '<a href="https://konsolowe.info/2026/03/new-article/">New</a>',
+            '<a href="/news/416201/new-article.html">New</a>',
         )
         main.jina.fetch_article_text = lambda url: "article-body"
 
         def fake_run_model(groq_api_key, model, options):
             prompt = options["prompt"]
             if "proofreading" in prompt:
-                return "Tytul: New\n\nPodsumowanie: gotowe.\n\nLink: https://konsolowe.info/2026/03/new-article/"
+                return "Tytul: New\n\nPodsumowanie: gotowe.\n\nLink: https://www.ppe.pl/news/416201/new-article.html"
             return "Tytul: New\n\nPodsumowanie: szkic."
 
         main.groq.run_groq_model = fake_run_model
@@ -85,7 +82,7 @@ class PipelineTests(unittest.TestCase):
         main.main()
 
         self.assertEqual(
-            [("https://konsolowe.info/2026/03/new-article/", "RAW")],
+            [("https://www.ppe.pl/news/416201/new-article.html", "RAW")],
             worksheet.appended_links,
         )
         self.assertEqual(1, len(sent_messages))
@@ -93,11 +90,11 @@ class PipelineTests(unittest.TestCase):
 
     def test_main_skips_existing_link_without_email(self):
         worksheet = FakeWorksheet(
-            values=[["Links"], ["https://konsolowe.info/2026/03/existing/"]]
+            values=[["Links"], ["https://www.ppe.pl/news/416200/existing.html"]]
         )
         sent_messages = self._configure_common(
             worksheet,
-            '<a href="https://konsolowe.info/2026/03/existing/">Existing</a>',
+            '<a href="/news/416200/existing.html">Existing</a>',
         )
         fetch_calls = []
         main.jina.fetch_article_text = lambda url: fetch_calls.append(url) or "article-body"
@@ -112,11 +109,11 @@ class PipelineTests(unittest.TestCase):
     def test_append_failure_stops_processing_link(self):
         worksheet = FakeWorksheet(
             values=[["Links"]],
-            append_fail_for={"https://konsolowe.info/2026/03/fail/"},
+            append_fail_for={"https://www.ppe.pl/news/416202/fail.html"},
         )
         sent_messages = self._configure_common(
             worksheet,
-            '<a href="https://konsolowe.info/2026/03/fail/">Fail</a>',
+            '<a href="/news/416202/fail.html">Fail</a>',
         )
         fetch_calls = []
         main.jina.fetch_article_text = lambda url: fetch_calls.append(url) or "article-body"
@@ -132,7 +129,7 @@ class PipelineTests(unittest.TestCase):
         worksheet = FakeWorksheet(values=[["Links"]])
         sent_messages = self._configure_common(
             worksheet,
-            '<a href="https://konsolowe.info/2026/03/fetch-fail/">Fail</a>',
+            '<a href="/news/416203/fetch-fail.html">Fail</a>',
         )
         main.jina.fetch_article_text = lambda url: (_ for _ in ()).throw(
             RuntimeError("fetch failed")
@@ -142,7 +139,7 @@ class PipelineTests(unittest.TestCase):
         main.main()
 
         self.assertEqual(
-            [("https://konsolowe.info/2026/03/fetch-fail/", "RAW")],
+            [("https://www.ppe.pl/news/416203/fetch-fail.html", "RAW")],
             worksheet.appended_links,
         )
         self.assertEqual([], sent_messages)

--- a/tests/test_milestone_1_4.py
+++ b/tests/test_milestone_1_4.py
@@ -114,6 +114,26 @@ class MilestoneOneFourTests(unittest.TestCase):
         self.assertEqual("hidden", captured_request["reasoning_format"])
         self.assertEqual(groq.QWEN_MIN_MAX_TOKENS, captured_request["max_tokens"])
 
+    def test_groq_client_uses_request_timeout(self):
+        captured_kwargs = {}
+        original_groq_class = groq.Groq
+
+        class FakeGroq:
+            def __init__(self, **kwargs):
+                captured_kwargs.update(kwargs)
+
+        try:
+            groq.Groq = FakeGroq
+            groq.groq_client("test-key")
+        finally:
+            groq.Groq = original_groq_class
+
+        self.assertEqual("test-key", captured_kwargs["api_key"])
+        self.assertEqual(
+            groq.GROQ_REQUEST_TIMEOUT_SECONDS,
+            captured_kwargs["timeout"],
+        )
+
     def test_run_groq_model_raises_clear_error_for_empty_content(self):
         original_client = groq.groq_client
 

--- a/tests/test_milestone_1_5.py
+++ b/tests/test_milestone_1_5.py
@@ -190,6 +190,27 @@ class MilestoneOneFivePipelineTests(unittest.TestCase):
         self.assertEqual([], result)
         self.assertEqual([], prompts)
 
+    def test_long_article_text_is_trimmed_before_summary_prompt(self):
+        prompts = []
+        long_article = " ".join(["dluga tresc artykulu"] * 2000)
+        main.jina.fetch_article_text = lambda url: long_article
+
+        def fake_run_model(groq_api_key, model, options):
+            prompts.append(options["prompt"])
+            return "Tytul: News\n\nPodsumowanie: Szkic."
+
+        main.groq.run_groq_model = fake_run_model
+
+        result = main.summarize_news(
+            {"GROQ_API": "test", "LLM_MODEL": "model"},
+            [ARTICLE_URL],
+        )
+
+        self.assertEqual(1, len(result))
+        self.assertEqual(1, len(prompts))
+        self.assertLess(len(prompts[0]), len(long_article))
+        self.assertIn("limit wejscia modelu", prompts[0])
+
     def test_incomplete_proofreading_result_is_not_sent(self):
         main.groq.run_groq_model = lambda groq_api_key, model, options: (
             "Tytuł: News\n\n"


### PR DESCRIPTION
## Zakres
- zmienia domyślne źródło newsów na `https://www.ppe.pl/gry`
- przełącza domyślny arkusz stanu na `gameflash_sheet_ppe`
- dostosowuje parser listingu do linków PPE `/news/<id>/<slug>.html`
- dodaje ograniczenie długości treści artykułu przed promptem LLM oraz timeout klienta Groq
- aktualizuje PRD, specyfikację, roadmapę, status projektu, README i testy

## Walidacja
- `uv run python -m unittest discover -s tests -p "test_*.py"`
- wynik: `Ran 38 tests`, `OK (skipped=1)`
- wykonano live run dla 3 newsów PPE zakończony wysyłką maila